### PR TITLE
Source service proxy settings from the current environment, check for…

### DIFF
--- a/scripts/hab-sup.service.sh
+++ b/scripts/hab-sup.service.sh
@@ -1,4 +1,16 @@
 mkdir -p /etc/systemd/system
+
+environment_proxy=""
+if [ ! -z "$HTTP_PROXY" ]; then
+  environment_proxy="\"HTTP_PROXY=${HTTP_PROXY}\" "
+fi
+if [ ! -z "$HTTPS_PROXY" ]; then
+  environment_proxy="\"HTTPS_PROXY=${HTTPS_PROXY}\" "
+fi
+if [ ! -z "${environment_proxy}" ]; then
+  environment_proxy="Environment=${environment_proxy}"
+fi
+
 cat <<EOT > /etc/systemd/system/hab-sup.service
 [Unit]
 Description=Habitat Supervisor
@@ -6,6 +18,7 @@ Description=Habitat Supervisor
 [Service]
 ExecStartPre=/bin/bash -c "/bin/systemctl set-environment SSL_CERT_FILE=$(hab pkg path core/cacerts)/ssl/cert.pem"
 ExecStart=/bin/hab run
+${environment_proxy}
 
 [Install]
 WantedBy=default.target

--- a/scripts/install-hab.sh
+++ b/scripts/install-hab.sh
@@ -1,2 +1,3 @@
+type curl >/dev/null 2>&1 || { echo >&2 "curl is required for installation of habitat, but was not found. Exiting."; exit 1; }
 curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash
 hab pkg install core/cacerts


### PR DESCRIPTION
… existence of curl before install

Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Notes:

* Check for `curl` before executing curl for hab install
* Pull proxy configuration from the environment the script was run. I think this makes sense to do by default, and is a nice convenience to have it injected into the service definition when its required.

The proxy injection might need a more elegant solution? Not sure.