### PR TITLE
Disable builder for on-prem

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -50,6 +50,7 @@ EOT
 log_level="debug"
 
 app_url = "http://${APP_HOSTNAME}:9636"
+enable_builder = false
 
 [github]
 url = "$GITHUB_API_URL"


### PR DESCRIPTION
Disable builder functionality for on-prem installs

Signed-off-by: Salim Alam <salam@chef.io>