### PR TITLE
Add some sane defaults for Bitbucket

### DIFF
--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -1,23 +1,28 @@
 #!/bin/bash
 
-# Modify these as needed for the on-premise OAuth2 provider
-# The OAuth2 URLs below are configured as an example of using
-# the GitHub cloud service as a provider.
+# Modify these as needed for the on-premise OAuth2 provider.
+# The variables below are configured for GitHub by default,
+# but appropriate values for bitbucket are also included as
+# comments.
 
 # The URL for this instance of the on-prem depot
 export APP_URL=http://localhost
 
 # The OAUTH_PROVIDER value can be either "github" or "bitbucket"
 export OAUTH_PROVIDER=github
+# export OAUTH_PROVIDER=bitbucket
 
 # The OAUTH_API_URL is the API endpoint that will be used for user info
 export OAUTH_API_URL=https://api.github.com
+# export OAUTH_API_URL=https://api.bitbucket.org
 
 # The OAUTH_AUTHORIZE_URL is the *fully qualified* OAuth2 authorization endpoint
 export OAUTH_AUTHORIZE_URL=https://github.com/login/oauth/authorize
+# export OAUTH_AUTHORIZE_URL=https://bitbucket.org/site/oauth2/authorize
 
 # THe OAUTH_TOKEN_URL is the *fully qualified* OAuth2 token endpoint
 export OAUTH_TOKEN_URL=https://github.com/login/oauth/access_token
+# export OAUTH_TOKEN_URL=https://bitbucket.org/site/oauth2/access_token
 
 # The OAUTH_REDIRECT_URL is the registered OAuth2 redirect
 export OAUTH_REDIRECT_URL=http://localhost/


### PR DESCRIPTION
Even if people are using on-prem Bitbucket, chances are good that only the domain name is going to change.  The URL structure is probably similar, if not identical.  Having some commented out sane defaults in this file will help people to not have to look everything up every time.

![](https://media.giphy.com/media/3o7TKnpFgAKwgZPxGo/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>