### PR TITLE
Fixes for scripts and README

### DIFF
--- a/scripts/on-prem-archive.sh
+++ b/scripts/on-prem-archive.sh
@@ -215,7 +215,7 @@ case "${1:-}" in
 
     if [ -f "${3:-}" ]; then
       echo "Skipping S3 download and using existing file $3 instead."
-      mv "$3" "$tmp_dir/$marker"
+      cp "$3" "$tmp_dir/$marker"
       cd "$tmp_dir"
     else
       echo "Fetching latest package bootstrap file."

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -35,6 +35,10 @@ configure() {
   mkdir -p /hab/svc/builder-api
   cat <<EOT > /hab/svc/builder-api/user.toml
 log_level="info"
+jobsrv_enabled = false
+
+[depot]
+jobsrv_enabled = false
 
 ["$OAUTH_PROVIDER"]
 enabled = true
@@ -365,16 +369,18 @@ start-sessionsrv() {
 }
 
 generate_bldr_keys() {
-  if [ -n "$(find /hab/cache/keys -name "bldr-*.pub")" ]; then
-    echo "Re-using existing builder key"
+  keys=( $(find /hab/cache/keys -name "bldr-*.pub") )
+
+  if [ "${#keys[@]}" -gt 0 ]; then
+    KEY_NAME=$(echo $keys[0] | grep -Po "bldr-\d+")
+    echo "Re-using existing builder key: $KEY_NAME"
   else
-    echo "Generating builder key"
     KEY_NAME=$(hab user key generate bldr | grep -Po "bldr-\d+")
-    for svc in api worker; do
-      hab file upload "builder-${svc}.default" "$(date +%s)" "/hab/cache/keys/${KEY_NAME}.pub"
-      hab file upload "builder-${svc}.default" "$(date +%s)" "/hab/cache/keys/${KEY_NAME}.box.key"
-    done
+    echo "Generated new builder key: $KEY_NAME"
   fi
+
+  hab file upload "builder-api.default" "$(date +%s)" "/hab/cache/keys/${KEY_NAME}.pub"
+  hab file upload "builder-api.default" "$(date +%s)" "/hab/cache/keys/${KEY_NAME}.box.key"
 }
 
 start-builder() {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-sudo hab svc status | tail -n +2 | grep "^habitat\/" | awk -F'/' '{print $2}' | xargs -I{} hab svc stop habitat/{}
-sudo hab svc status | tail -n +2 | grep "^habitat\/" | awk -F'/' '{print $2}' | xargs -I{} hab svc unload habitat/{}
-sudo rm -rf /hab/pkgs/habitat
+hab svc status | tail -n +2 | grep "^habitat\/" | awk -F'/' '{print $2}' | xargs -I{} hab svc stop habitat/{}
+hab svc status | tail -n +2 | grep "^habitat\/" | awk -F'/' '{print $2}' | xargs -I{} hab svc unload habitat/{}
+rm -rf /hab/pkgs/habitat


### PR DESCRIPTION
This PR has some fixes for the provision scripts:
- Fix a rt:route:2 error when bootstrapping packages
- Upload builder key to api service if it already exists
- Update the uninstall script
- Update some sections in the README

Signed-off-by: Salim Alam <salam@chef.io>