### PR TITLE
Do sudo -E to pass in proxy env to svc load

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -348,27 +348,27 @@ EOT
 }
 
 start-api() {
-  hab svc load habitat/builder-api --bind router:builder-router.default --channel "${BLDR_CHANNEL}" --force
+  sudo -E hab svc load habitat/builder-api --bind router:builder-router.default --channel "${BLDR_CHANNEL}" --force
 }
 
 start-api-proxy() {
-  hab svc load habitat/builder-api-proxy --bind http:builder-api.default --channel "${BLDR_CHANNEL}" --force
+  sudo -E hab svc load habitat/builder-api-proxy --bind http:builder-api.default --channel "${BLDR_CHANNEL}" --force
 }
 
 start-datastore() {
-  hab svc load habitat/builder-datastore --channel "${BLDR_CHANNEL}" --force
+  sudo -E hab svc load habitat/builder-datastore --channel "${BLDR_CHANNEL}" --force
 }
 
 start-originsrv() {
-  hab svc load habitat/builder-originsrv --bind router:builder-router.default --bind datastore:builder-datastore.default --channel "${BLDR_CHANNEL}" --force
+  sudo -E hab svc load habitat/builder-originsrv --bind router:builder-router.default --bind datastore:builder-datastore.default --channel "${BLDR_CHANNEL}" --force
 }
 
 start-router() {
-  hab svc load habitat/builder-router --channel "${BLDR_CHANNEL}" --force
+  sudo -E hab svc load habitat/builder-router --channel "${BLDR_CHANNEL}" --force
 }
 
 start-sessionsrv() {
-  hab svc load habitat/builder-sessionsrv --bind router:builder-router.default --bind datastore:builder-datastore.default --channel "${BLDR_CHANNEL}" --force
+  sudo -E hab svc load habitat/builder-sessionsrv --bind router:builder-router.default --bind datastore:builder-datastore.default --channel "${BLDR_CHANNEL}" --force
 }
 
 generate_bldr_keys() {


### PR DESCRIPTION
When a http proxy is being used, the proxy env does not get propagated to the service load, which can fail on package install.  This change adds a sudo -E to the svc load to fix this.

Signed-off-by: Salim Alam <salam@chef.io>