### PR TITLE
Add Azure AD provider info

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following are minimum requirements for installation/deployment of the Habita
 * Services should be deployed single-node - scale out is not yet supported
 * Outbound network (HTTPS) connectivity to WAN is required for the _initial_ install
 * Inbound network connectivity from LAN (HTTP) is required for internal clients to access the depot
-* OAuth2 authentication provider (GitHub, GitHub Enterprise, GitLab and Bitbucket have been verified - additional providers may be added on request)
+* OAuth2 authentication provider (Azure AD, GitHub, GitHub Enterprise, GitLab and Bitbucket have been verified - additional providers may be added on request)
 
 ## Functionality
 
@@ -53,7 +53,7 @@ You may need to work with your enterprise network admin to enable the appropriat
 
 ### OAuth Application
 
-We currently support GitHub, GitLab and Atlassian Bitbucket OAuth providers for authentication. You will need to set up an OAuth application for the instance of the depot you are setting up.
+We currently support Azure AD (OpenId Connect), GitHub, GitLab and Atlassian Bitbucket OAuth providers for authentication. You will need to set up an OAuth application for the instance of the depot you are setting up.
 
 Refer to the steps that are specific to your OAuth provider to create and configure your OAuth application. The below steps illustrate setting up the OAuth application using Github as the identity provider:
 

--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -8,25 +8,29 @@
 # The URL for this instance of the on-prem depot
 export APP_URL=http://localhost
 
-# The OAUTH_PROVIDER value can be "github", "gitlab" or "bitbucket"
+# The OAUTH_PROVIDER value can be "github", "gitlab", "bitbucket" or "azure-ad"
 export OAUTH_PROVIDER=github
 # export OAUTH_PROVIDER=bitbucket
 # export OAUTH_PROVIDER=gitlab
+# export OAUTH_PROVIDER=azure-ad
 
 # The OAUTH_USERINFO_URL is the API endpoint that will be used for user info
 export OAUTH_USERINFO_URL=https://api.github.com/user
 # export OAUTH_USERINFO_URL=https://api.bitbucket.org/1.0/user
 # export OAUTH_USERINFO_URL=https://gitlab.com/api/v4/user
+# export OAUTH_USERINFO_URL=https://login.microsoftonline.com/<tenant-id>/openid/userinfo
 
 # The OAUTH_AUTHORIZE_URL is the *fully qualified* OAuth2 authorization endpoint
 export OAUTH_AUTHORIZE_URL=https://github.com/login/oauth/authorize
 # export OAUTH_AUTHORIZE_URL=https://bitbucket.org/site/oauth2/authorize
 # export OAUTH_AUTHORIZE_URL=https://gitlab.com/oauth/authorize
+# export OAUTH_AUTHORIZE_URL=https://login.microsoftonline.com/<tenant-id>/oauth2/authorize
 
 # THe OAUTH_TOKEN_URL is the *fully qualified* OAuth2 token endpoint
 export OAUTH_TOKEN_URL=https://github.com/login/oauth/access_token
 # export OAUTH_TOKEN_URL=https://bitbucket.org/site/oauth2/access_token
 # export OAUTH_TOKEN_URL=https://gitlab.com/oauth/token
+# export OAUTH_TOKEN_URL=https://login.microsoftonline.com/<tenant-id>/oauth2/token
 
 # The OAUTH_REDIRECT_URL is the registered OAuth2 redirect
 export OAUTH_REDIRECT_URL=http://localhost/


### PR DESCRIPTION
This updates the README and config for Azure AD auth.

Azure AD auth will be usable _after_ the Azure AD-enabled packages for builder-api and builder-sessionsrv are promoted to stable.

Signed-off-by: Salim Alam <salam@chef.io>