### PR TITLE
Add -E to sudo in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 pushd scripts > /dev/null
-sudo ./install-hab.sh
-sudo ./hab-sup.service.sh
-sudo ./provision.sh
+sudo -E ./install-hab.sh
+sudo -E ./hab-sup.service.sh
+sudo -E ./provision.sh
 popd > /dev/null


### PR DESCRIPTION
For the use case where a proxy is being injected via an environment variable for installation, we need to add the -E option to the sudo in the install script.

Signed-off-by: Salim Alam <salam@chef.io>