### PR TITLE
Add SSL enablement

### DIFF
--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -5,7 +5,11 @@
 # but appropriate values for Bitbucket and GitLab are also included
 # as comments.
 
+# Whether SSL is enabled for the on-prem depot
+export APP_SSL_ENABLED=false
+
 # The URL for this instance of the on-prem depot
+# IMPORTANT: If SSL is enabled, APP_URL should start be https
 export APP_URL=http://localhost
 
 # The OAUTH_PROVIDER value can be "github", "gitlab", "bitbucket" or "azure-ad"
@@ -33,6 +37,7 @@ export OAUTH_TOKEN_URL=https://github.com/login/oauth/access_token
 # export OAUTH_TOKEN_URL=https://login.microsoftonline.com/<tenant-id>/oauth2/token
 
 # The OAUTH_REDIRECT_URL is the registered OAuth2 redirect
+# IMPORTANT: If SSL is enabled, the redirect URL should be https
 export OAUTH_REDIRECT_URL=http://localhost/
 
 # The OAUTH_CLIENT_ID is the registered OAuth2 client id


### PR DESCRIPTION
This change adds instructions (and related script changes) for enabling SSL on the UI/API endpoints for the on-prem depot.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-260598948](https://user-images.githubusercontent.com/13542112/39657961-1e372c28-4fc2-11e8-9464-5beda5fa9e30.gif)
