### PR TITLE
Update documenentation and examples for OAuth providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following are minimum requirements for installation/deployment of the Habita
 * Services should be deployed single-node - scale out is not yet supported
 * Outbound network (HTTPS) connectivity to WAN is required for the _initial_ install
 * Inbound network connectivity from LAN (HTTP/HTTPS) is required for internal clients to access the depot
-* OAuth2 authentication provider (Azure AD, GitHub, GitHub Enterprise, GitLab and Bitbucket have been verified - additional providers may be added on request)
+* OAuth2 authentication provider (Azure AD, GitHub, GitHub Enterprise, GitLab, Okta and Bitbucket have been verified - additional providers may be added on request)
 
 ## Functionality
 
@@ -53,7 +53,7 @@ You may need to work with your enterprise network admin to enable the appropriat
 
 ### OAuth Application
 
-We currently support Azure AD (OpenId Connect), GitHub, GitLab and Atlassian Bitbucket OAuth providers for authentication. You will need to set up an OAuth application for the instance of the depot you are setting up.
+We currently support Azure AD (OpenId Connect), GitHub, GitLab (OpenId Connect), Okta (OpenId Connect) and Atlassian Bitbucket OAuth providers for authentication. You will need to set up an OAuth application for the instance of the depot you are setting up.
 
 Refer to the steps that are specific to your OAuth provider to create and configure your OAuth application. The below steps illustrate setting up the OAuth application using Github as the identity provider:
 
@@ -67,8 +67,12 @@ For the configuration below, you will also need to know following *fully qualifi
 * Token Endpoint (example: `https://github.com/login/oauth/access_token`)
 * API Endpoint (example: `https://api.github.com`)
 
-For more information, please refer to the
-[GitHub Developer Documentation](https://developer.github.com/apps/building-oauth-apps/authorization-options-for-oauth-apps/) or the [BitBucket Developer Documentation](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html).
+For more information, please refer to the developer documentation of these services:
+* [Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code)
+* [GitHub](https://developer.github.com/apps/building-oauth-apps/authorization-options-for-oauth-apps/)
+* [GitLab](https://docs.gitlab.com/ee/integration/oauth_provider.html)
+* [Okta](https://developer.okta.com/authentication-guide/implementing-authentication/auth-code)
+* [BitBucket](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html)
 
 Further information on the OAuth endpoints can also be found [here](https://tools.ietf.org/html/rfc6749#page-21).
 

--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -2,8 +2,8 @@
 
 # Modify these as needed for the on-premise OAuth2 provider.
 # The variables below are configured for GitHub by default,
-# but appropriate values for Bitbucket and GitLab are also included
-# as comments.
+# but appropriate values for Bitbucket, GitLab, Azure AD and Okta
+# are also included as comments.
 
 # Whether SSL is enabled for the on-prem depot
 export APP_SSL_ENABLED=false
@@ -12,29 +12,33 @@ export APP_SSL_ENABLED=false
 # IMPORTANT: If SSL is enabled, APP_URL should start be https
 export APP_URL=http://localhost
 
-# The OAUTH_PROVIDER value can be "github", "gitlab", "bitbucket" or "azure-ad"
+# The OAUTH_PROVIDER value can be "github", "gitlab", "bitbucket", "azure-ad" or "okta"
 export OAUTH_PROVIDER=github
 # export OAUTH_PROVIDER=bitbucket
 # export OAUTH_PROVIDER=gitlab
 # export OAUTH_PROVIDER=azure-ad
+# export OAUTH_PROVIDER=okta
 
 # The OAUTH_USERINFO_URL is the API endpoint that will be used for user info
 export OAUTH_USERINFO_URL=https://api.github.com/user
 # export OAUTH_USERINFO_URL=https://api.bitbucket.org/1.0/user
-# export OAUTH_USERINFO_URL=https://gitlab.com/api/v4/user
+# export OAUTH_USERINFO_URL=https://gitlab.com/oauth/userinfo
 # export OAUTH_USERINFO_URL=https://login.microsoftonline.com/<tenant-id>/openid/userinfo
+# export OAUTH_USERINFO_URL=https://<your.okta.domain>.com/oauth2/v1/userinfo
 
 # The OAUTH_AUTHORIZE_URL is the *fully qualified* OAuth2 authorization endpoint
 export OAUTH_AUTHORIZE_URL=https://github.com/login/oauth/authorize
 # export OAUTH_AUTHORIZE_URL=https://bitbucket.org/site/oauth2/authorize
 # export OAUTH_AUTHORIZE_URL=https://gitlab.com/oauth/authorize
 # export OAUTH_AUTHORIZE_URL=https://login.microsoftonline.com/<tenant-id>/oauth2/authorize
+# export OAUTH_AUTHORIZE_URL=https://<your.okta.domain>.com/oauth2/v1/authorize
 
 # THe OAUTH_TOKEN_URL is the *fully qualified* OAuth2 token endpoint
 export OAUTH_TOKEN_URL=https://github.com/login/oauth/access_token
 # export OAUTH_TOKEN_URL=https://bitbucket.org/site/oauth2/access_token
 # export OAUTH_TOKEN_URL=https://gitlab.com/oauth/token
 # export OAUTH_TOKEN_URL=https://login.microsoftonline.com/<tenant-id>/oauth2/token
+# export OAUTH_TOKEN_URL=https://<your.okta.domain>.com/oauth2/v1/token
 
 # The OAUTH_REDIRECT_URL is the registered OAuth2 redirect
 # IMPORTANT: If SSL is enabled, the redirect URL should be https


### PR DESCRIPTION
Update the documentation and add example environment variables for Okta and the updated GitLab support.

I've also added documentation links for the other services.

This depends on https://github.com/habitat-sh/builder/pull/417 and https://github.com/habitat-sh/builder/pull/420 becoming available in stable.