### PR TITLE
Update default channel to on-prem-stable

### DIFF
--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -51,4 +51,4 @@ export OAUTH_CLIENT_ID=<YOUR-CLIENT-ID>
 export OAUTH_CLIENT_SECRET=<YOUR-CLIENT-SECRET>
 
 # Modify this only if there is a specific need, otherwise leave as is
-export BLDR_CHANNEL=stable
+export BLDR_CHANNEL=on-prem-stable


### PR DESCRIPTION
Update the default install channel for builder packages to on-prem-stable. This will allow a different cadence for the on-prem builder installs than the hosted builder.

Signed-off-by: Salim Alam <salam@chef.io>