### PR TITLE
Patch install script for hab 0.56.0

### DIFF
--- a/scripts/install-hab.sh
+++ b/scripts/install-hab.sh
@@ -1,3 +1,4 @@
 type curl >/dev/null 2>&1 || { echo >&2 "curl is required for installation of habitat, but was not found. Exiting."; exit 1; }
 curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash
 hab pkg install core/cacerts
+hab pkg install core/hab-sup


### PR DESCRIPTION
Update the install script to pull in an updated version of hab-sup.  This is required to update to hab 0.56.0

Signed-off-by: Salim Alam <salam@chef.io>