### PR TITLE
Enable opt-in analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/privat
 1. Clone this repo (or unzip the archive you have been given) at the desired machine where you will stand up the Habitat Builder Depot
 1. `cd ${SRC_ROOT}`
 1. `cp bldr.env.sample bldr.env`
-1. Edit `bldr.env` with a text editor and replace the values appropriately
+1. Edit `bldr.env` with a text editor and replace the values appropriately. Consider helping us to improve Habitat as well by changing the `ANALYTICS_ENABLED` setting to `true` and providing an optional company name.
 1. `./install.sh`
 
 If everything goes well, you should see output similar to the following showing that the depot services are loaded:

--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -55,6 +55,6 @@ export BLDR_CHANNEL=on-prem-stable
 
 # Help us make Habitat better! Opt into analytics by changing the ANALYTICS_ENABLED
 # setting below to true, then optionally provide your company name. (Analytics is
-# disabled by default.)
+# disabled by default. See our privacy policy at https://www.habitat.sh/legal/privacy-policy/.)
 export ANALYTICS_ENABLED=false
 export ANALYTICS_COMPANY_NAME=""

--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -33,7 +33,7 @@ export OAUTH_AUTHORIZE_URL=https://github.com/login/oauth/authorize
 # export OAUTH_AUTHORIZE_URL=https://login.microsoftonline.com/<tenant-id>/oauth2/authorize
 # export OAUTH_AUTHORIZE_URL=https://<your.okta.domain>.com/oauth2/v1/authorize
 
-# THe OAUTH_TOKEN_URL is the *fully qualified* OAuth2 token endpoint
+# The OAUTH_TOKEN_URL is the *fully qualified* OAuth2 token endpoint
 export OAUTH_TOKEN_URL=https://github.com/login/oauth/access_token
 # export OAUTH_TOKEN_URL=https://bitbucket.org/site/oauth2/access_token
 # export OAUTH_TOKEN_URL=https://gitlab.com/oauth/token
@@ -52,3 +52,9 @@ export OAUTH_CLIENT_SECRET=0123456789abcdef0123456789abcdef01234567
 
 # Modify this only if there is a specific need, otherwise leave as is
 export BLDR_CHANNEL=on-prem-stable
+
+# Help us make Habitat better! Opt into analytics by changing the ANALYTICS_ENABLED
+# setting below to true, then optionally provide your company name. (Analytics is
+# disabled by default.)
+export ANALYTICS_ENABLED=false
+export ANALYTICS_COMPANY_NAME=""

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -32,6 +32,10 @@ configure() {
   export PGPASSWORD
   PGPASSWORD=$(cat /hab/svc/builder-datastore/config/pwfile)
 
+  export ANALYTICS_ENABLED=${ANALYTICS_ENABLED:="false"}
+  export ANALYTICS_COMPANY_ID=${ANALYTICS_COMPANY_ID:="builder-on-prem"}
+  export ANALYTICS_WRITE_KEY=${ANALYTICS_WRITE_KEY:="NAwVPW04CeESMW3vtyqjJZmVMNBSQ1K1"}
+
   mkdir -p /hab/svc/builder-api
   cat <<EOT > /hab/svc/builder-api/user.toml
 log_level="info"
@@ -47,6 +51,10 @@ token_url = "$OAUTH_TOKEN_URL"
 redirect_url = "$OAUTH_REDIRECT_URL"
 client_id = "$OAUTH_CLIENT_ID"
 client_secret = "$OAUTH_CLIENT_SECRET"
+
+[segment]
+url = "https://api.segment.io"
+write_key = "$ANALYTICS_WRITE_KEY"
 EOT
 
   mkdir -p /hab/svc/builder-api-proxy
@@ -71,6 +79,12 @@ keepalive_timeout = "180s"
 
 [server]
 listen_tls = $APP_SSL_ENABLED
+
+[analytics]
+enabled = $ANALYTICS_ENABLED
+company_id = "$ANALYTICS_COMPANY_ID"
+company_name = "$ANALYTICS_COMPANY_NAME"
+write_key = "$ANALYTICS_WRITE_KEY"
 EOT
 
   mkdir -p /hab/svc/builder-originsrv

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -33,8 +33,14 @@ configure() {
   PGPASSWORD=$(cat /hab/svc/builder-datastore/config/pwfile)
 
   export ANALYTICS_ENABLED=${ANALYTICS_ENABLED:="false"}
-  export ANALYTICS_COMPANY_ID=${ANALYTICS_COMPANY_ID:="builder-on-prem"}
-  export ANALYTICS_WRITE_KEY=${ANALYTICS_WRITE_KEY:="NAwVPW04CeESMW3vtyqjJZmVMNBSQ1K1"}
+  export ANALYTICS_COMPANY_ID
+  export ANALYTICS_COMPANY_NAME
+  export ANALYTICS_WRITE_KEY
+
+  if [ $ANALYTICS_ENABLED = "true" ]; then
+    ANALYTICS_WRITE_KEY=${ANALYTICS_WRITE_KEY:="NAwVPW04CeESMW3vtyqjJZmVMNBSQ1K1"}
+    ANALYTICS_COMPANY_ID=${ANALYTICS_COMPANY_ID:="builder-on-prem"}
+  fi
 
   mkdir -p /hab/svc/builder-api
   cat <<EOT > /hab/svc/builder-api/user.toml


### PR DESCRIPTION
This change allows users to opt into sharing usage data by changing one or more values in `bldr.env`.

Signed-off-by: Christian Nunciato <chris@nunciato.org>