### PR TITLE
Add Chef Automate A2 as OAuth provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following are minimum requirements for installation/deployment of the Habita
 * Services should be deployed single-node - scale out is not yet supported
 * Outbound network (HTTPS) connectivity to WAN is required for the _initial_ install
 * Inbound network connectivity from LAN (HTTP/HTTPS) is required for internal clients to access the depot
-* OAuth2 authentication provider (Azure AD, GitHub, GitHub Enterprise, GitLab, Okta and Bitbucket (cloud) have been verified - additional providers may be added on request)
+* OAuth2 authentication provider (Chef Automate v2, Azure AD, GitHub, GitHub Enterprise, GitLab, Okta and Bitbucket (cloud) have been verified - additional providers may be added on request)
 
 ## Functionality
 
@@ -60,7 +60,7 @@ You may need to work with your enterprise network admin to enable the appropriat
 
 ### OAuth Application
 
-We currently support Azure AD (OpenId Connect), GitHub, GitLab (OpenId Connect), Okta (OpenId Connect) and Atlassian Bitbucket (cloud) OAuth providers for authentication. You will need to set up an OAuth application for the instance of the depot you are setting up.
+We currently support Chef Automate v2, Azure AD (OpenId Connect), GitHub, GitLab (OpenId Connect), Okta (OpenId Connect) and Atlassian Bitbucket (cloud) OAuth providers for authentication. You will need to set up an OAuth application for the instance of the depot you are setting up.
 
 Refer to the steps that are specific to your OAuth provider to create and configure your OAuth application. The below steps illustrate setting up the OAuth application using Github as the identity provider:
 
@@ -75,6 +75,7 @@ For the configuration below, you will also need to know following *fully qualifi
 * API Endpoint (example: `https://api.github.com`)
 
 For more information, please refer to the developer documentation of these services:
+* [Chef Automate](https://automate.chef.io/docs/configuration/#setting-up-automate-as-an-oauth-provider-for-builder)
 * [Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code)
 * [GitHub](https://developer.github.com/apps/building-oauth-apps/authorization-options-for-oauth-apps/)
 * [GitLab](https://docs.gitlab.com/ee/integration/oauth_provider.html)
@@ -82,6 +83,8 @@ For more information, please refer to the developer documentation of these servi
 * [BitBucket](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html)
 
 Further information on the OAuth endpoints can also be found [here](https://tools.ietf.org/html/rfc6749#page-21).
+
+*Note*: When setting Chef Automate as your OAuth provider, you will need to add your Automate instance's TLS certificate (found at the `load_balancer.v1.sys.frontend_tls` entry in your Chef Automate `config.toml` file), to your Builder instance's list of accepted certs. Currently, this can be done by modifying the `core/cacert` package and appending the cert to the cert.pem file at the following location: `$(hab pkg path core/cacerts)/ssl/cert.pem`.
 
 ### Preparing your filesystem (Optional)
 

--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -19,12 +19,14 @@ export APP_SSL_ENABLED=false
 # IMPORTANT: If SSL is enabled, APP_URL should start be https
 export APP_URL=http://localhost
 
-# The OAUTH_PROVIDER value can be "github", "gitlab", "bitbucket", "azure-ad" or "okta"
+# The OAUTH_PROVIDER value can be "github", "gitlab", "bitbucket", "azure-ad",
+# "okta" or "chef-automate"
 export OAUTH_PROVIDER=github
 # export OAUTH_PROVIDER=bitbucket
 # export OAUTH_PROVIDER=gitlab
 # export OAUTH_PROVIDER=azure-ad
 # export OAUTH_PROVIDER=okta
+# export OAUTH_PROVIDER=chef-automate
 
 # The OAUTH_USERINFO_URL is the API endpoint that will be used for user info
 export OAUTH_USERINFO_URL=https://api.github.com/user
@@ -32,6 +34,7 @@ export OAUTH_USERINFO_URL=https://api.github.com/user
 # export OAUTH_USERINFO_URL=https://gitlab.com/oauth/userinfo
 # export OAUTH_USERINFO_URL=https://login.microsoftonline.com/<tenant-id>/openid/userinfo
 # export OAUTH_USERINFO_URL=https://<your.okta.domain>.com/oauth2/v1/userinfo
+# export OAUTH_USERINFO_URL=https://<your.automate.domain>/session/userinfo
 
 # The OAUTH_AUTHORIZE_URL is the *fully qualified* OAuth2 authorization endpoint
 export OAUTH_AUTHORIZE_URL=https://github.com/login/oauth/authorize
@@ -39,6 +42,7 @@ export OAUTH_AUTHORIZE_URL=https://github.com/login/oauth/authorize
 # export OAUTH_AUTHORIZE_URL=https://gitlab.com/oauth/authorize
 # export OAUTH_AUTHORIZE_URL=https://login.microsoftonline.com/<tenant-id>/oauth2/authorize
 # export OAUTH_AUTHORIZE_URL=https://<your.okta.domain>.com/oauth2/v1/authorize
+# export OAUTH_AUTHORIZE_URL=https://<your.automate.domain>/session/new
 
 # The OAUTH_TOKEN_URL is the *fully qualified* OAuth2 token endpoint
 export OAUTH_TOKEN_URL=https://github.com/login/oauth/access_token
@@ -46,6 +50,7 @@ export OAUTH_TOKEN_URL=https://github.com/login/oauth/access_token
 # export OAUTH_TOKEN_URL=https://gitlab.com/oauth/token
 # export OAUTH_TOKEN_URL=https://login.microsoftonline.com/tenant-id/oauth2/token
 # export OAUTH_TOKEN_URL=https://your.okta.domain.com/oauth2/v1/token
+# export OAUTH_TOKEN_URL=https://<your.automate.domain>/session/token
 
 # The OAUTH_REDIRECT_URL is the registered OAuth2 redirect
 # IMPORTANT: If SSL is enabled, the redirect URL should be https


### PR DESCRIPTION
This change updates the README and bldr.env.sample to add Chef Automate v2 as an OAuth provider.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-63640747](https://user-images.githubusercontent.com/13542112/43232452-c0d9c294-9025-11e8-9629-408c936a0e9d.gif)
