### PR TITLE
Add wait for hab-sup to come up full before proceeding with deploy

### DIFF
--- a/scripts/hab-sup.service.sh
+++ b/scripts/hab-sup.service.sh
@@ -26,3 +26,8 @@ EOT
 
 systemctl daemon-reload
 systemctl start hab-sup
+
+# wait for the sup to come up before proceeding.
+until hab svc status > /dev/null 2>&1; do
+  sleep 1
+done


### PR DESCRIPTION
This commit adds a wait to `scripts/hab-sup.service.sh` which will cause `hab-sup.service.sh` to block until the `hab-sup` is up and accepting connections.

This resolves the issue encountered in #87 

Thanks
- Q