### PR TITLE
Add a helm chart for the on-prem builder.

### DIFF
--- a/helm/habitat-builder/.helmignore
+++ b/helm/habitat-builder/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/habitat-builder/Chart.yaml
+++ b/helm/habitat-builder/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+description: The Habitat On-Prem builder
+engine: gotpl
+name: habitat-builder
+sources:
+ - https://github.com/habitat-sh/on-prem-builder
+version: 0.1.0

--- a/helm/habitat-builder/README.md
+++ b/helm/habitat-builder/README.md
@@ -1,0 +1,159 @@
+# On Premises Depot
+
+The on premises depot is a self hosted version of the Habitat Builder service.
+
+## Install Chart
+
+To install the chart into your kubernetes cluster:
+
+```console
+helm repo add builder https://habitat-sh.github.io/on-prem-depot/helm/charts/stable/
+helm install --name my-builder builder/habitat-builder
+```
+
+This deploys the chart using the default configuration.
+
+## Uninstall Chart
+
+To uninstall/delete the `my-builder` deployment:
+
+```console
+helm delete my-builder
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the habitat-builder chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`image.registry` | Image Registry | `hub.docker.com`
+`image.tag` | Image Tag to be deployed | `on-prem-stable`
+`datastore.superuserPassword` | Password for Postgres | None
+`datastore.persistentStorage.enabled` | Use a Persistent volume for the database | `false`
+`datastore.persistentStorage.size` | Size of volume to create | `32Gi`
+`datastore.persistentStorage.storageClass` | Type of storage to create | `default`
+`minio.secret_key` | Password for Minio datastore | `password`
+`minio.persistentStorage.enabled` | Use a Persistent volume for the block storage | `false`
+`minio.persistentStorage.size` | Size of volume to create | `32Gi`
+`minio.persistentStorage.storageClass` | Type of storage to create | `default`
+`app.ssl.enabled` | Should SSL/HTTPS be enabled | `false`
+`app.ssl.crt` | The contents of the SSL certificate file | None
+`app.ssl.key` | The contents of the SSL key file | None
+`app.fqdn` | The FQDN for this instance of the on-prem depot | `localhost`
+`api.keys.name` | The name of the service keypair | None
+`api.keys.public_key` | The contents of the service public_key file | None
+`api.keys.private_key` | The contents of the service priate key file | None
+`oauth.provider` | OAuth provider | `github`
+`oauth.authorize_url`| The OAuth User Info URL | `"https://github.com/login/oauth/authorize"`
+`oauth.token_url`| The OAuth User Info URL | `"https://github.com/login/oauth/access_token"`
+`oauth.client_id`| Your registered Oauth2 client id | `0123456789abcdef0123`
+`oauth.client_secret`| Your registered Oauth2 client id | `0123456789abcdef0123456789abcdef01234567`
+`analytics.enabled` | Should analytics data be send back | `false`
+`analytics.company_name` | identifier for this on-prem builder | `""`
+`service.type` | How to expose the API as a service | `LoadBalancer`
+`service.loadBalancerIP` | Use a pre-allocated IP | None
+`debug` | turn on service debug logs | `false`
+
+Specify each parameter using the --set key=value[,key=value] argument to helm install. For example,
+
+```console
+helm install --name my-builder builder/habitat-builder \
+  --set app.ssl.enabled=true
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install --name my-builder builder/habitat-builder -f values.yaml
+```
+
+## Common Configuration Setups
+
+### Minimal configuration
+
+In order to have a functional depot you'll need to set the following at a minimum:
+
+    * `app.fqdn`
+    * `datastore.superuserPassword`
+    * `oauth.client_id`
+    * `oauith.client_secret`
+    * `api.keys.name`
+    * `api.keys.public_key`
+    * `api.keys.private_key`
+
+See the sections below for more details on setting each of these.
+
+### Setting a database password
+
+You must set a database password as `datastore.superuserPassword`.
+
+### OAuth Setup
+
+See [OAuth Application setup](https://github.com/habitat-sh/on-prem-builder/blob/master/README.md#oauth-application) for how to configure OAuth. [values.yaml](values.yaml) contains the correct URLs for the OAuth services that are supported.
+
+### Setting API Keys
+
+The API services needs a set of signing keys. You can generate these using `hab key generate` on your workstation:
+
+```console
+KEY_NAME=$(hab user key generate on-prem-bldr | grep -Po "on-prem-bldr-\\d+")
+echo "Generated new builder key: $KEY_NAME"
+
+helm install my-builder builder/habitat-builder install \
+    --set api.keys.name=${KEY_NAME} \
+    --set-file api.keys.public_key=$HOME/.hab/cache/keys/${KEY_NAME}.pub \
+    --set-file api.keys.private_key=$HOME/.hab/cache/keys/${KEY_NAME}.box.key
+```
+
+You can also set them in a YAML `values.yaml` file, e.g.:
+
+```yaml
+api:
+  keys:
+    name: "bldr-20180827040405"
+    public_key: |-
+      BOX-PUB-1
+      bldr-20180827040405
+
+      qw9CXWK4N3yMhD6Qhya21ohDH0ZIbl0myZ8j8R4uOQk=
+    private_key: |-
+      BOX-SEC-1
+      bldr-20180827040405
+
+      4VT5l4yeDaG11wvIWrw/RhkEyH+dZSRo4HlCatgWwEE=
+```
+
+where `public_key` and `private_key` are the contents of the `.pub` and `.box.key` files respectively.
+
+### Enabling SSL/HTTPS
+
+By default the on premise depot only exposes a HTTP port. In order to allow HTTPS traffic you will need to provide SSL a certificate for the service to use. If you don't have one you can generate a self signed certificate:
+
+```console
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ssl-certificate.key -out ssl-certificate.crt
+```
+
+This should provided to helm via the `--set-file` option:
+
+```console
+helm install my-builder builder/habitat-builder install \
+    --set app.ssl.enabled=true \
+    --set-file app.ssl.crt=./ssl-certificate.crt \
+    --set-file app.ssl.key=./ssl-certificate.key
+```
+
+Alternative you can paste the contents of the two files into your `values.yaml` similar to the example above for API keys.
+
+### Using pre-allocated IP
+
+If you have a static IP assigned already to the service FQDN that you would like the Load Balancer to use, you can specify it via the `service.loadBalancerIP`. If you don't specify it then an IP address will be assigned and you'll need to configure DNS to point to it.
+
+## Post-Install steps
+
+To bootstrap the core packages origin on your depot follow the instructions at
+https://github.com/habitat-sh/on-prem-builder/blob/master/README.md#depot-web-ui
+
+## Hosting
+
+The Helm chart repository is managed on the [`gh-pages` branch](https://github.com/habitat-sh/on-prem-builder/tree/gh-pages) and instructions for repository management can be found [here](https://github.com/habitat-sh/on-prem-builder/tree/gh-pages/helm/charts).

--- a/helm/habitat-builder/conf/builder-api-proxy.toml
+++ b/helm/habitat-builder/conf/builder-api-proxy.toml
@@ -4,6 +4,7 @@ log_level="debug"
 log_level="info"
 {{- end }}
 enable_builder = false
+load_balanced = true
 app_url = {{ template "habitat-builder.app_url" . }}
 
 [oauth]

--- a/helm/habitat-builder/conf/builder-api-proxy.toml
+++ b/helm/habitat-builder/conf/builder-api-proxy.toml
@@ -1,0 +1,32 @@
+{{- if .Values.debug }}
+log_level="debug"
+{{- else }}
+log_level="info"
+{{- end }}
+enable_builder = false
+app_url = {{ template "habitat-builder.app_url" . }}
+
+[oauth]
+provider = {{ .Values.oauth.provider | quote }}
+client_id = {{ .Values.oauth.client_id | quote }}
+authorize_url = {{ .Values.oauth.authorize_url | quote }}
+redirect_url = {{ template "habitat-builder.app_url" . }}
+
+[nginx]
+max_body_size = "2048m"
+proxy_send_timeout = 180
+proxy_read_timeout = 180
+enable_gzip = true
+enable_caching = true
+
+[http]
+keepalive_timeout = "180s"
+
+[server]
+listen_tls = {{ .Values.app.ssl.enabled }}
+
+[analytics]
+enabled = {{ .Values.analytics.enabled }}
+company_id = {{ .Values.analytics.company_id | quote }}
+company_name = {{ .Values.analytics.company_name | quote }}
+write_key = {{ .Values.analytics.write_key | quote }}

--- a/helm/habitat-builder/conf/builder-api.toml
+++ b/helm/habitat-builder/conf/builder-api.toml
@@ -1,0 +1,42 @@
+{{- if .Values.debug }}
+log_level="debug,tokio_core=error,tokio_reactor=error,zmq=error,hyper=error"
+{{- else }}
+log_level="error,tokio_core=error,tokio_reactor=error,zmq=error,hyper=error"
+{{- end }}
+jobsrv_enabled = false
+
+[http]
+handler_count = 10
+
+[api]
+features_enabled = ""
+targets = ["x86_64-linux", "x86_64-linux-kernel2", "x86_64-windows"]
+
+[depot]
+jobsrv_enabled = false
+
+[oauth]
+provider = {{ .Values.oauth.provider | quote }}
+userinfo_url = {{ .Values.oauth.userinfo_url | quote }}
+token_url = {{ .Values.oauth.token_url | quote}}
+redirect_url = {{ template "habitat-builder.app_url" . }}
+client_id = {{ .Values.oauth.client_id | quote }}
+client_secret = {{ .Values.oauth.client_secret | quote }}
+
+[segment]
+url = "https://api.segment.io"
+write_key = {{ .Values.analytics.write_key | quote }}
+
+[s3]
+backend = "minio"
+key_id = {{ .Values.minio.key_id | quote }}
+secret_key = {{ .Values.minio.secret_key | quote }}
+endpoint = 'http://{{ template "habitat-builder.fullname" . }}-minio-int:9000'
+bucket_name = {{ .Values.minio.bucket_name | quote }}
+
+[memcache]
+ttl = 1
+
+[datastore]
+password = {{ required "A valid datastore.superuserPassword required!" .Values.datastore.superuserPassword | quote }}
+connection_timeout_sec = 5

--- a/helm/habitat-builder/conf/builder-datastore.toml
+++ b/helm/habitat-builder/conf/builder-datastore.toml
@@ -1,0 +1,4 @@
+max_locks_per_transaction = 128
+
+[init]
+superuser_password = {{ required "A valid datastore.superuserPassword required!" .Values.datastore.superuserPassword | quote }}

--- a/helm/habitat-builder/conf/builder-minio.toml
+++ b/helm/habitat-builder/conf/builder-minio.toml
@@ -1,0 +1,3 @@
+key_id = {{ .Values.minio.key_id | quote }}
+secret_key = {{ .Values.minio.secret_key | quote }}
+bucket_name = {{ .Values.minio.bucket_name | quote }}

--- a/helm/habitat-builder/templates/NOTES.txt
+++ b/helm/habitat-builder/templates/NOTES.txt
@@ -1,0 +1,26 @@
+When the on-premises depot has started it can be accessed at:
+{{ if .Values.app.ssl.enabled }}
+{{ printf "  https://%s" .Values.app.fqdn }}
+{{- else }}
+{{ printf "  http://%s" .Values.app.fqdn }}
+{{- end }}
+
+You can check if the service is configured and available by checking for an available EXTERNAL-IP:
+
+  kubectl get services --namespace {{ .Release.Namespace }} {{ template "habitat-builder.fullname" . }}-api-ext
+
+{{ if not .Values.api.keys.name }}
+WARNING: The on-premises depot requires builder keys and these have not been
+installed yet as part of the installation process e.g:
+
+    KEY_NAME=$(hab user key generate on-prem-bldr | grep -Po "on-prem-bldr-\\d+")
+    echo "Generated new builder key: $KEY_NAME"
+
+    helm upgrade {{ .Release.Name }} \
+      --set api.keys.name=${KEY_NAME} \
+      --set-file api.keys.public_key=$HOME/.hab/cache/keys/${KEY_NAME}.pub \
+      --set-file api.keys.private_key=$HOME/.hab/cache/keys/${KEY_NAME}.box.key
+{{- end }}
+
+To bootstrap the core packages origin on your depot follow the instructions at
+https://github.com/habitat-sh/on-prem-builder/blob/master/README.md#depot-web-ui

--- a/helm/habitat-builder/templates/_helpers.tpl
+++ b/helm/habitat-builder/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "habitat-builder.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 52 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "habitat-builder.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 52 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 52 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "habitat-builder.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Application URL
+*/}}
+{{- define "habitat-builder.app_url" -}}
+{{ if .Values.app.ssl.enabled -}}
+{{- printf "https://%s" .Values.app.fqdn | quote -}}
+{{- else -}}
+{{- printf "http://%s" .Values.app.fqdn | quote -}}
+{{- end -}}
+{{- end -}}

--- a/helm/habitat-builder/templates/api-files.yml
+++ b/helm/habitat-builder/templates/api-files.yml
@@ -1,0 +1,17 @@
+{{- if .Values.api.keys.name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name:  {{ template "habitat-builder.fullname" . }}-api-files
+  labels:
+    app: {{ template "habitat-builder.name" . }}
+    chart: {{ template "habitat-builder.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  {{ .Values.api.keys.name }}.pub: |-
+    {{ required "An API public_key is required!" .Values.api.keys.public_key | b64enc }}
+  {{ .Values.api.keys.name }}.box.key: |-
+    {{ required "An API pricvate_key is required!" .Values.api.keys.private_key | b64enc }}
+{{- end }}

--- a/helm/habitat-builder/templates/api-habitat.yml
+++ b/helm/habitat-builder/templates/api-habitat.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: habitat.sh/v1beta1
+kind: Habitat
+customVersion: v1beta2
+metadata:
+  name: {{ template "habitat-builder.fullname" . }}-api
+  labels:
+    app: {{ template "habitat-builder.name" . }}
+    chart: {{ template "habitat-builder.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  v1beta2:
+    image: "{{ .Values.image.registry }}/habitat/builder-api:{{ .Values.image.tag }}"
+    count: 1
+    service:
+      name: builder-api
+      topology: standalone
+      configSecretName:  {{ template "habitat-builder.fullname" . }}-api-toml
+      {{- if .Values.api.keys.name }}
+      filesSecretName:  {{ template "habitat-builder.fullname" . }}-api-files
+      {{- end }}
+      bind:
+        - name: memcached
+          service: builder-memcached
+          group: default
+        - name: datastore
+          service: builder-datastore
+          group: default

--- a/helm/habitat-builder/templates/api-proxy-files.yml
+++ b/helm/habitat-builder/templates/api-proxy-files.yml
@@ -1,0 +1,17 @@
+{{- if .Values.app.ssl.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name:  {{ template "habitat-builder.fullname" . }}-api-proxy-files
+  labels:
+    app: {{ template "habitat-builder.name" . }}
+    chart: {{ template "habitat-builder.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  ssl-certificate.crt: |-
+    {{ required "A SSL certificate is required!" .Values.app.ssl.crt | b64enc }}
+  ssl-certificate.key: |-
+    {{ required "A SSL private key is required!" .Values.app.ssl.key | b64enc }}
+{{- end }}

--- a/helm/habitat-builder/templates/api-proxy-habitat.yml
+++ b/helm/habitat-builder/templates/api-proxy-habitat.yml
@@ -1,0 +1,25 @@
+apiVersion: habitat.sh/v1beta1
+kind: Habitat
+customVersion: v1beta2
+metadata:
+  name: {{ template "habitat-builder.fullname" . }}-api-proxy
+  labels:
+    app: {{ template "habitat-builder.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  v1beta2:
+    image: "{{ .Values.image.registry }}/habitat/builder-api-proxy:{{ .Values.image.tag }}"
+    count: 1
+    service:
+      name: builder-api-proxy
+      topology: standalone
+      configSecretName: {{ template "habitat-builder.fullname" . }}-api-proxy-toml
+      {{- if .Values.app.ssl.enabled }}
+      filesSecretName:  {{ template "habitat-builder.fullname" . }}-api-proxy-files
+      {{- end }}
+      bind:
+        - name: http
+          service: builder-api
+          group: default

--- a/helm/habitat-builder/templates/api-proxy-secret.yml
+++ b/helm/habitat-builder/templates/api-proxy-secret.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "habitat-builder.fullname" . }}-api-proxy-toml
+  labels:
+    app: {{ template "habitat-builder.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  user.toml: |-
+    {{ tpl (.Files.Get  "conf/builder-api-proxy.toml") . | b64enc }}

--- a/helm/habitat-builder/templates/api-proxy-service.yml
+++ b/helm/habitat-builder/templates/api-proxy-service.yml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name:  {{ template "habitat-builder.fullname" . }}-api-ext
+  labels:
+    app: {{ template "habitat-builder.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+  - name: http
+    port: 80
+{{- if .Values.app.ssl.enabled }}
+  - name: https
+    port: 443
+{{- end }}
+  selector:
+    habitat-name: {{ template "habitat-builder.fullname" . }}-api-proxy

--- a/helm/habitat-builder/templates/api-secret.yml
+++ b/helm/habitat-builder/templates/api-secret.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "habitat-builder.fullname" . }}-api-toml
+  labels:
+    app: {{ template "habitat-builder.name" . }}
+    chart: {{ template "habitat-builder.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  user.toml: |-
+    {{ tpl (.Files.Get  "conf/builder-api.toml") . | b64enc }}

--- a/helm/habitat-builder/templates/datastore-habitat.yml
+++ b/helm/habitat-builder/templates/datastore-habitat.yml
@@ -1,0 +1,28 @@
+apiVersion: habitat.sh/v1beta1
+kind: Habitat
+customVersion: v1beta2
+metadata:
+  name: {{ template "habitat-builder.fullname" . }}-datastore
+  labels:
+    app: {{ template "habitat-builder.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  v1beta2:
+    image: "{{ .Values.image.registry }}/habitat/builder-datastore:{{ .Values.image.tag }}"
+    count: 1
+    {{- if .Values.datastore.persistentStorage.enabled }}
+    persistentStorage:
+      size: {{ .Values.datastore.persistentStorage.size }}
+      {{- if .Values.datastore.persistentStorage.storageClass }}
+      storageClassName: {{ .Values.datastore.persistentStorage.storageClass }}
+      {{- else }}
+      storageClassName: ""
+      {{- end }}
+      mountPath: /hab/svc/builder-datastore/data
+    {{- end }}
+    service:
+      name: builder-datastore
+      topology: standalone
+      configSecretName: {{ template "habitat-builder.fullname" . }}-datastore-toml

--- a/helm/habitat-builder/templates/datastore-secret.yml
+++ b/helm/habitat-builder/templates/datastore-secret.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "habitat-builder.fullname" . }}-datastore-toml
+  labels:
+    app: {{ template "habitat-builder.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  user.toml: |-
+    {{ tpl (.Files.Get  "conf/builder-datastore.toml") . | b64enc }}

--- a/helm/habitat-builder/templates/memcached-habitat.yml
+++ b/helm/habitat-builder/templates/memcached-habitat.yml
@@ -1,0 +1,17 @@
+apiVersion: habitat.sh/v1beta1
+kind: Habitat
+customVersion: v1beta2
+metadata:
+  name: {{ template "habitat-builder.fullname" . }}-memcached
+  labels:
+    app: {{ template "habitat-builder.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  v1beta2:
+    image: "{{ .Values.image.registry }}/habitat/builder-memcached:{{ .Values.image.tag }}"
+    count: 1
+    service:
+      name: builder-memcached
+      topology: standalone

--- a/helm/habitat-builder/templates/minio-habitat.yml
+++ b/helm/habitat-builder/templates/minio-habitat.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: habitat.sh/v1beta1
+kind: Habitat
+customVersion: v1beta2
+metadata:
+  name: {{ template "habitat-builder.fullname" . }}-minio
+  labels:
+    app: {{ template "habitat-builder.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  v1beta2:
+    image: "{{ .Values.image.registry }}/habitat/builder-minio:{{ .Values.image.tag }}"
+    count: 1
+    {{- if .Values.minio.persistentStorage.enabled }}
+    persistentStorage:
+      size: {{ .Values.minio.persistentStorage.size }}
+      {{- if .Values.minio.persistentStorage.storageClass }}
+      storageClassName: {{ .Values.minio.persistentStorage.storageClass }}
+      {{- else }}
+      storageClassName: ""
+      {{- end }}
+      mountPath: /hab/svc/builder-minio/data
+    {{- end }}
+    service:
+      name: builder-minio
+      topology: standalone
+      configSecretName: {{ template "habitat-builder.fullname" . }}-minio-toml

--- a/helm/habitat-builder/templates/minio-secret.yml
+++ b/helm/habitat-builder/templates/minio-secret.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "habitat-builder.fullname" . }}-minio-toml
+  labels:
+    app: {{ template "habitat-builder.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  user.toml: |-
+    {{ tpl (.Files.Get  "conf/builder-minio.toml") . | b64enc }}

--- a/helm/habitat-builder/templates/minio-sv-debug.yml
+++ b/helm/habitat-builder/templates/minio-sv-debug.yml
@@ -1,0 +1,19 @@
+{{- if .Values.debug }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "habitat-builder.fullname" . }}-minio-ext
+  labels:
+    app: "{{ template "habitat-builder.name" . }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: http
+    port: 80
+    targetPort: 9000
+  selector:
+    habitat-name:  {{ template "habitat-builder.fullname" . }}-minio
+{{- end }}

--- a/helm/habitat-builder/templates/minio-sv.yml
+++ b/helm/habitat-builder/templates/minio-sv.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name:  {{ template "habitat-builder.fullname" . }}-minio-int
+  labels:
+    app: {{ template "habitat-builder.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  ports:
+  - name: http
+    port: 9000
+    protocol: TCP
+  selector:
+    habitat-name: {{ template "habitat-builder.fullname" . }}-minio

--- a/helm/habitat-builder/values.yaml
+++ b/helm/habitat-builder/values.yaml
@@ -1,0 +1,111 @@
+# Default values for habitat-builder.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  registry: hub.docker.com
+  tag: on-prem-stable
+
+datastore:
+  ## The datastore password is required to be set in order to install the helm chart.
+  ## There is no default
+  # superuserPassword: ""
+
+  persistentStorage:
+    enabled: false
+    size: 32Gi
+    storageClass: "default"
+
+
+## The key and secret for your Minio instance (see README)
+## Change these before the first install if needed
+minio:
+  bucket_name: "habitat-builder-artifact-store.local"
+  key_id: "depot"
+  secret_key: "password"
+  persistentStorage:
+    enabled: false
+    size: 100Gi
+    storageClass: "default"
+
+app:
+  ## Whether SSL is enabled for the on-prem depot.  If ssl.enabled is true
+  ## then you should provide the contents of .crt and .key files too
+  ssl:
+    enabled: false
+    crt:
+    key:
+  ## THe FQDN for this instance of the on-prem depot
+  fqdn: "localhost"
+
+api:
+  # keys:
+  #   name: "bldr-20180827040405"
+  #   public_key: |-
+  #     BOX-PUB-1
+  #     bldr-20180827040405
+
+  #     qw9CXWK4N3yMhD6Qhya21ohDH0ZIbl0myZ8j8R4uOQk=
+  #   private_key: |-
+  #     BOX-SEC-1
+  #     bldr-20180827040405
+
+  #     4VT5l4yeDaG11wvIWrw/RhkEyH+dZSRo4HlCatgWwEE=
+
+## Modify these as needed for the on-premise OAuth2 provider.
+## The variables below are configured for GitHub by default,
+## but appropriate values for Bitbucket, GitLab, Azure AD and Okta
+## are also included as comments.
+oauth:
+  ## The .Values.oauth.provider value can be "github", "gitlab", "bitbucket",
+  ## "azure-ad","okta" or "chef-automate"
+  provider: "github"
+
+  ## The .Values.oauth.userinfo is the API endpoint that will be used for user info
+  ##
+  # userinfo_url: https://api.bitbucket.org/1.0/user
+  # userinfo_url: https://gitlab.com/oauth/userinfo
+  # userinfo_url: https://login.microsoftonline.com/<tenant-id>/openid/userinfo
+  # userinfo_url: https://<your.okta.domain>.com/oauth2/v1/userinfo
+  # userinfo_url: https://<your.automate.domain>/session/userinfo
+  userinfo_url: "https://api.github.com/user"
+
+  ## The .Values.oauth.authorize_url is the *fully qualified* OAuth2 authorization endpoint
+  ##
+  # authorize_url: https://bitbucket.org/site/oauth2/authorize
+  # authorize_url: https://gitlab.com/oauth/authorize
+  # authorize_url: https://login.microsoftonline.com/<tenant-id>/oauth2/authorize
+  # authorize_url: https://<your.okta.domain>.com/oauth2/v1/authorize
+  # authorize_url: https://<your.automate.domain>/session/new
+  authorize_url: "https://github.com/login/oauth/authorize"
+
+  ## The .Values.oauth.token_url is the *fully qualified* OAuth2 token endpoint
+  ##
+  # token_url: https://bitbucket.org/site/oauth2/access_token
+  # token_url: https://gitlab.com/oauth/token
+  # token_url: https://login.microsoftonline.com/tenant-id/oauth2/token
+  # token_url: https://your.okta.domain.com/oauth2/v1/token
+  # token_url: https://<your.automate.domain>/session/token
+  token_url: "https://github.com/login/oauth/access_token"
+
+  ## The .Values.oauth.client_id is the registered OAuth2 client id
+  client_id: "0123456789abcdef0123"
+
+  ## The .Values.oauth.client_secret is the registerd OAuth2 client secret
+  client_secret: "0123456789abcdef0123456789abcdef01234567"
+
+## Help us make Habitat better! Opt into analytics by changing the ANALYTICS_ENABLED
+## setting below to true, then optionally provide your company name. (Analytics is
+## disabled by default. See our privacy policy at https://www.habitat.sh/legal/privacy-policy/.)
+analytics:
+  enabled: false
+  company_id: "builder-on-prem"
+  write_key: "NAwVPW04CeESMW3vtyqjJZmVMNBSQ1K1"
+  company_name: ""
+
+service:
+  type: LoadBalancer
+  ## Set if you've got a statically assigned IP
+  # loadBalancerIP:
+
+debug: false


### PR DESCRIPTION
This adds a helm chart to deploy all the services for the on-prem
builder.

It supports
 * Persistent volumes for minio and postgres
 * uploading of bldr API keys via a secret
 * Uploading of all configuration files via secrets

It has been tested in AKS, GKE and minikube.

TODO:

- [ ] docker images need to be build automatically and published
- [x] Look at using builder-datastore rather than core/postgresql96
- [x] Need habitat-sh/builder#617 to be merged
- [x] Need habitat-sh/core-plans#1843 to be merged
- [x] Need habitat-sh/habitat-operator#351 to be merged
- [x] Complete README.md and NOTES.txt
- [x] Test on minikube

Signed-off-by: James Casey <james@chef.io>