### PR TITLE
Don't need to configure minio in provision.sh

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -285,19 +285,7 @@ start_router() {
 }
 
 start_minio() {
-  hab pkg install core/aws-cli
-  hab pkg binlink core/aws-cli -f aws
-  export AWS_ACCESS_KEY_ID="$MINIO_ACCESS_KEY"
-  export AWS_SECRET_ACCESS_KEY="$MINIO_SECRET_KEY"
-
-  sudo -E hab svc load "${BLDR_ORIGIN}/builder-minio" --channel "${BLDR_CHANNEL}" --force
-
-  if aws --endpoint-url $MINIO_ENDPOINT s3api list-buckets | grep "$MINIO_BUCKET" > /dev/null; then
-    echo "Minio already configured"
-  else
-    echo "Creating bucket in Minio"
-    aws --endpoint-url $MINIO_ENDPOINT s3api create-bucket --bucket "$MINIO_BUCKET"
-  fi
+  sudo -E hab svc load habitat/builder-minio --channel "${BLDR_CHANNEL}" --force
 }
 
 start_memcached() {


### PR DESCRIPTION
This is the matching commit to habitat-sh/builder#617 which strips out
the redundant configuration

Tested that it works along with the builder PR by deploying via terraform, sshing to the box and checking that the bucket is there:

```
source builder/bldr.env
export AWS_ACCESS_KEY_ID="$MINIO_ACCESS_KEY"
export AWS_SECRET_ACCESS_KEY="$MINIO_SECRET_KEY"
aws --endpoint-url "${MINIO_ENDPOINT}"  s3api list-buckets
```

Output:
```
{
    "Owner": {
        "DisplayName": "", 
        "ID": "02d6176db174dc93cb1b899f7c6078f08654445fe8cf1b6ce98d8855f66bdbf4"
    }, 
    "Buckets": [
        {
            "CreationDate": "2018-09-14T00:41:20.393Z", 
            "Name": "habitat-builder-artifact-store.default"
        }
    ]
}
```
NOTE: Tested against private packages in my origin.  Will need the updated builder-minio to be built and pushed to the on-prem-stable channel before merging or this will break for customers.

Signed-off-by: James Casey <james@chef.io>