### PR TITLE
Allow for a different origin to be used to pull packages from

### DIFF
--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -62,8 +62,9 @@ export OAUTH_CLIENT_ID=0123456789abcdef0123
 # The OAUTH_CLIENT_SECRET is the registerd OAuth2 client secret
 export OAUTH_CLIENT_SECRET=0123456789abcdef0123456789abcdef01234567
 
-# Modify this only if there is a specific need, otherwise leave as is
+# Modify these only if there is a specific need, otherwise leave as is
 export BLDR_CHANNEL=on-prem-stable
+export BLDR_ORIGIN=habitat
 
 # Help us make Habitat better! Opt into analytics by changing the ANALYTICS_ENABLED
 # setting below to true, then optionally provide your company name. (Analytics is

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -11,6 +11,9 @@ else
   exit 1
 fi
 
+# Defaults
+BLDR_ORIGIN=${BLDR_ORIGIN:="habitat"}
+
 init_datastore() {
   mkdir -p /hab/svc/builder-datastore
   cat <<EOT > /hab/svc/builder-datastore/user.toml
@@ -398,27 +401,27 @@ EOT
 }
 
 start_api() {
-  sudo -E hab svc load habitat/builder-api --bind router:builder-router.default --channel "${BLDR_CHANNEL}" --force
+  sudo -E hab svc load "${BLDR_ORIGIN}/builder-api" --bind router:builder-router.default --channel "${BLDR_CHANNEL}" --force
 }
 
 start_api_proxy() {
-  sudo -E hab svc load habitat/builder-api-proxy --bind http:builder-api.default --channel "${BLDR_CHANNEL}" --force
+  sudo -E hab svc load "${BLDR_ORIGIN}/builder-api-proxy" --bind http:builder-api.default --channel "${BLDR_CHANNEL}" --force
 }
 
 start_datastore() {
-  sudo -E hab svc load habitat/builder-datastore --channel "${BLDR_CHANNEL}" --force
+  sudo -E hab svc load "${BLDR_ORIGIN}/builder-datastore" --channel "${BLDR_CHANNEL}" --force
 }
 
 start_originsrv() {
-  sudo -E hab svc load habitat/builder-originsrv --bind router:builder-router.default --bind datastore:builder-datastore.default --channel "${BLDR_CHANNEL}" --force
+  sudo -E hab svc load "${BLDR_ORIGIN}/builder-originsrv" --bind router:builder-router.default --bind datastore:builder-datastore.default --channel "${BLDR_CHANNEL}" --force
 }
 
 start_router() {
-  sudo -E hab svc load habitat/builder-router --channel "${BLDR_CHANNEL}" --force
+  sudo -E hab svc load "${BLDR_ORIGIN}/builder-router" --channel "${BLDR_CHANNEL}" --force
 }
 
 start_sessionsrv() {
-  sudo -E hab svc load habitat/builder-sessionsrv --bind router:builder-router.default --bind datastore:builder-datastore.default --channel "${BLDR_CHANNEL}" --force
+  sudo -E hab svc load "${BLDR_ORIGIN}/builder-sessionsrv" --bind router:builder-router.default --bind datastore:builder-datastore.default --channel "${BLDR_CHANNEL}" --force
 }
 
 start_minio() {
@@ -427,7 +430,7 @@ start_minio() {
   export AWS_ACCESS_KEY_ID="$MINIO_ACCESS_KEY"
   export AWS_SECRET_ACCESS_KEY="$MINIO_SECRET_KEY"
 
-  sudo -E hab svc load habitat/builder-minio --channel "${BLDR_CHANNEL}" --force
+  sudo -E hab svc load "${BLDR_ORIGIN}/builder-minio" --channel "${BLDR_CHANNEL}" --force
 
   if aws --endpoint-url $MINIO_ENDPOINT s3api list-buckets | grep "$MINIO_BUCKET" > /dev/null; then
     echo "Minio already configured"


### PR DESCRIPTION
I wanted to be able to do development on builder for on-prem without
having rights to the habitat origin.  This PR justs adds the
ability to specify a different origin in bldr.env.

It also sets a default in provision.sh so that existing users
don't run into problems using an existing `bldr.env` file

Testing:
* Created on-prem builder via terraform with no changes to the `bldr.env` and
the standard version from the habitat is run

Expected output:
```
$ sudo hab svc status
package                                         type        desired  state  elapsed (s)  pid   group
habitat/builder-datastore/7311/20180426183913   standalone  up       up     3111         1745  builder-datastore.default
habitat/builder-minio/0.1.0/20180612201128      standalone  up       up     3094         1778  builder-minio.default
habitat/builder-router/7519/20180731190111      standalone  up       up     3094         1792  builder-router.default
habitat/builder-api/7554/20180808175204         standalone  up       up     3082         1806  builder-api.default
habitat/builder-originsrv/7582/20180822212645   standalone  up       up     3055         1939  builder-originsrv.default
habitat/builder-api-proxy/7519/20180731190110   standalone  up       up     3055         2007  builder-api-proxy.default
habitat/builder-sessionsrv/7582/20180822212645  standalone  up       up     3050         2051  builder-sessionsrv.default
```

* Point at a different origin (in this case `jamesc`) and channel (in this case `unstable`) in bldr.env and deploy again

```
$ diff bldr.env.sample bldr.env
66,67c66,68
< export BLDR_CHANNEL=on-prem-stable
< export BLDR_ORIGIN=habitat
---
> #export BLDR_CHANNEL=on-prem-stable
> export BLDR_CHANNEL=unstable
> export BLDR_ORIGIN=jamesc
```

```
$ sudo hab svc status
package                                        type        desired  state  elapsed (s)  pid   group
jamesc/builder-datastore/7634/20180913230310   standalone  up       up     230          1745  builder-datastore.default
jamesc/builder-minio/0.1.0/20180914000556      standalone  up       up     208          1765  builder-minio.default
jamesc/builder-api/7634/20180913150028         standalone  up       up     187          1825  builder-api.default
jamesc/builder-router/7634/20180913161135      standalone  up       up     187          1916  builder-router.default
jamesc/builder-originsrv/7634/20180913230717   standalone  up       up     176          1959  builder-originsrv.default
jamesc/builder-api-proxy/7634/20180913160412   standalone  up       up     176          2022  builder-api-proxy.default
jamesc/builder-sessionsrv/7634/20180912235009  standalone  up       up     170          2061  builder-sessionsrv.default
```

Signed-off-by: James Casey <james@chef.io>