### PR TITLE
Enable gzip and caching

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -99,6 +99,8 @@ redirect_url = "$OAUTH_REDIRECT_URL"
 max_body_size = "2048m"
 proxy_send_timeout = 180
 proxy_read_timeout = 180
+enable_gzip = true
+enable_caching = true
 
 [http]
 keepalive_timeout = "180s"


### PR DESCRIPTION
Enable gzip and caching on the front end proxy

Signed-off-by: Salim Alam <salam@chef.io>