### PR TITLE
Fixup bad rebase of #96 which broke using minio from a different origin

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -285,7 +285,7 @@ start_router() {
 }
 
 start_minio() {
-  sudo -E hab svc load habitat/builder-minio --channel "${BLDR_CHANNEL}" --force
+  sudo -E hab svc load "${BLDR_ORIGIN}/builder-minio" --channel "${BLDR_CHANNEL}" --force
 }
 
 start_memcached() {


### PR DESCRIPTION
In re-basing #96 I lost a usage of ${BLDR_ORIGIN} when starting minio that had been in #97. This
fixes it.

Signed-off-by: James Casey <james@chef.io>