### PR TITLE
add support for creating the s3 bucket defined in the bldr.env

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -53,6 +53,7 @@ configure() {
   cat <<EOT > /hab/svc/builder-minio/user.toml
 key_id = "depot"
 secret_key = "password"
+bucket_name = "$MINIO_BUCKET"
 EOT
 
   mkdir -p /hab/svc/builder-api


### PR DESCRIPTION
This came from a deployment where we had used the on-prem default for the bucket, and builder-minio had something else:

from [bldr.env.sample](https://github.com/habitat-sh/on-prem-builder/blob/4836726906fd4bd8546c87666490b5f7d7fe203f/bldr.env.sample#L6)

```
export MINIO_BUCKET=habitat-builder-artifact-store.local
```

---

from [builder-minio/habitat/default.toml#L5](https://github.com/habitat-sh/builder/blob/a9ed0f194e8ff295c07b07e01fd7b0617a287d11/components/builder-minio/habitat/default.toml#L5)

```
bucket_name = "habitat-builder-artifact-store.default"
```

I'm not sure if the same thing should be done for the minio credentials.


Signed-off-by: skylerto <skylerclayne@gmail.com>