### PR TITLE
Set minio bucket name config

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -53,6 +53,7 @@ configure() {
   cat <<EOT > /hab/svc/builder-minio/user.toml
 key_id = "depot"
 secret_key = "password"
+bucket_name = "$MINIO_BUCKET"
 EOT
 
   mkdir -p /hab/svc/builder-api


### PR DESCRIPTION
The latest habitat/builder-minio needs to have the bucket name config set explicitly

Signed-off-by: Salim Alam <salam@chef.io>