### PR TITLE
Update uninstall script to use systemctl and manually remove spec files

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-hab svc status | tail -n +2 | grep "^habitat\/" | awk -F'/' '{print $2}' | xargs -I{} hab svc stop habitat/{}
-hab svc status | tail -n +2 | grep "^habitat\/" | awk -F'/' '{print $2}' | xargs -I{} hab svc unload habitat/{}
+systemctl stop hab-sup
+rm -rf /hab/sup/default/specs/builder-*
 rm -rf /hab/pkgs/habitat


### PR DESCRIPTION
We can get into a state with the current uninstall script where the spec files can be left on disk, which can confuse the hab supervisor when it gets re-run on a new install.  This change manually force removes the spec files, and also uses systemctl to do the services stop and unload.

Signed-off-by: Salim Alam <salam@chef.io>