### PR TITLE
Updated provision script to properly respect MINIO credentials

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -51,8 +51,8 @@ configure() {
 
   mkdir -p /hab/svc/builder-minio
   cat <<EOT > /hab/svc/builder-minio/user.toml
-key_id = "depot"
-secret_key = "password"
+key_id = "$MINIO_ACCESS_KEY"
+secret_key = "$MINIO_SECRET_KEY"
 bucket_name = "$MINIO_BUCKET"
 EOT
 


### PR DESCRIPTION
Previously, the configs for consuming minio properly respected the bldr.env, however minio itself did not. If a user were to use non-default minio credentials, it would cause a mismatch and fail.