### PR TITLE
Add systemd config to prevent open file errors, etc

### DIFF
--- a/scripts/hab-sup.service.sh
+++ b/scripts/hab-sup.service.sh
@@ -24,6 +24,9 @@ Description=Habitat Supervisor
 [Service]
 ExecStartPre=/bin/bash -c "/bin/systemctl set-environment SSL_CERT_FILE=${SSL_CERT_FILE}"
 ExecStart=/bin/hab run
+ExecStop=/bin/hab sup term
+KillMode=process
+LimitNOFILE=65535
 ${environment_proxy}
 
 [Install]


### PR DESCRIPTION
This ports over some configs from the Builder SaaS infra to on-prem. Specifically, it will help prevent the dreaded "No more open files" error message, and improve other behavior.

Signed-off-by: Salim Alam <salam@chef.io>