### PR TITLE
Enable Artifactory usage for object store (alpha)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,11 @@ Further information on the OAuth endpoints can also be found [here](https://tool
 
 Since substantial storage may be required for holding packages, please ensure you have an appropriate amount of free space on your filesystem.
 
-The package artifacts will be stored in your Minio instance, typically at the following location: `/hab/svc/builder-minio/data`
+The package artifacts will be stored in your Minio instance by default, typically at the following location: `/hab/svc/builder-minio/data`
 
 If you need to add additional storage, it is recommended that you create a mount at `/hab` and point it to your external storage. This is not required if you already have sufficient free space.
+
+*Note*: If you would prefer to Artifactory instead of Minio for the object storage, please see the [Artifactory](#using-artifactory-as-the-object-store-(alpha)) section below.
 
 ### Procuring SSL certificate (Recommended)
 
@@ -367,6 +369,32 @@ The `builder-api-proxy` service will log (via Nginx) all access and errors to lo
         endscript
 }
 ```
+
+## Using Artifactory as the object store (Alpha)
+
+If you are interested in using an existing instance of Artifactory as your object store instead of Minio,
+we are providing this capability as an early preview/alpha for testing.
+
+To set this up, you will need to have the following:
+* Know the URL to the Artifactory instance
+* Know (or generate) an API key to authenticate to the instance
+* Create a repo for the Habitat artifacts
+
+Once you have the above, modify the your `bldr.env` based on the same config in `bldr.env.sample` in order to enable Artifactory.
+
+Once you have `bldr.env` updated, you can do an install normally using the `install.sh` script.
+
+After logging into the Depot Web UI and creating your origins, you can try uploading some packages and check your Artifactory instance to ensure that they are present in the repo you specified.
+
+If you run into any issues, please see the Support section below.
+
+### Running a local Artifactory
+
+If you just want to do a quick test, you can also run a local Artifactory instance. In order to do that, you can do the following:
+```
+sudo hab svc load core/artifactory
+```
+This will spin up an Artifactory instance, and you can use the following to log in: http://localhost:8081/artifactory/webapp/#/home
 
 ## Support
 

--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -7,6 +7,14 @@ export MINIO_BUCKET=habitat-builder-artifact-store.local
 export MINIO_ACCESS_KEY=depot
 export MINIO_SECRET_KEY=password
 
+# If you'd like to use Arifactory instead of Minio, uncomment
+# and set the following variables appropriately.
+# IMPORTANT: See the README for more info
+# export ARTIFACTORY_ENABLED=true
+# export ARTIFACTORY_API_URL=http://localhost:8081
+# export ARTIFACTORY_API_KEY=foo
+# export ARTIFACTORY_REPO=habitat-builder-artifact-store
+
 # Modify these as needed for the on-premise OAuth2 provider.
 # The variables below are configured for GitHub by default,
 # but appropriate values for Bitbucket, GitLab, Azure AD and Okta


### PR DESCRIPTION
This adds an option to enable Artifactory as the object store instead of Minio.
More info in the README below.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-222838247](https://user-images.githubusercontent.com/13542112/56312085-482a3580-6104-11e9-8a4b-019e865da163.gif)
