### PR TITLE
Remove any carriage returns from locally parsed tdeps

### DIFF
--- a/scripts/on-prem-archive.sh
+++ b/scripts/on-prem-archive.sh
@@ -311,9 +311,11 @@ case "${1:-}" in
 
             for dep in $tdeps
             do
+              # Windows TDEPs will have carriage returns, which we need to remove
+              dep_fixed=`echo $dep | sed 's/\\r//g'`
               dep_count=$((dep_count+1))
-              file_to_check="$tmp_dir/harts/$(tr '/' '-' <<< "$dep")-$target.hart"
-              download_hart_if_missing "$file_to_check" "$dep" "[$pkg_count/$pkg_total] [$dep_count/$dep_total]" "$target" || true
+              file_to_check="$tmp_dir/harts/$(tr '/' '-' <<< "$dep_fixed")-$target.hart"
+              download_hart_if_missing "$file_to_check" "$dep_fixed" "[$pkg_count/$pkg_total] [$dep_count/$dep_total]" "$target" || true
             done
           else
             echo "[$pkg_count/$pkg_total] $slash_ident has no TDEPS file. Skipping processing of dependencies."


### PR DESCRIPTION
This strips any carriage returns from the locally parsed tdeps. #145 exposed that curl was failing on all windows based tdeps like:

```
[631/743] core/rust/1.34.0/20190412161219 has the following 2 transitive dependencies:

core/visual-cpp-redist-2015/14.0.23026/20190128180056
core/visual-cpp-build-tools-2015/14.0.25420/20181108222024

Processing dependencies now.

[631/743] [1/2] Downloading core/visual-cpp-redist-2015/14.0.23026/20190128180056
curl: (3) Illegal characters found in URL
[631/743] [2/2] Downloading core/visual-cpp-build-tools-2015/14.0.25420/20181108222024
curl: (3) Illegal characters found in URL
```

The cause was that tdeps on windows have carriage returns, which was causing the construction of `file_to_check` and `curl` to fail. 

Prior to the fix, adding some debug statements:

```
              echo "Dep: ${dep}"
              dep_count=$((dep_count+1))
              echo $tmp_dir

              file_to_check="$(tr '/' '-' <<< "$dep")-$target.hart"
              echo $file_to_check
              path_to_check="${tmp_dir}/harts/$file_to_check"
              echo $path_to_check
```

Resulted in the following for windows packages:

```
Dep: core/bzip2/1.0.6/20181108223504
/tmp/tmp.IvBNYlgvMh
-x86_64-windows.hart81108223504
-x86_64-windows.hartharts/core-bzip2-1.0.6-20181108223504
[3/25] [6/6] Downloading core/bzip2/1.0.6/20181108223504
curl: (3) Illegal characters found in URL
```