### PR TITLE
Adds the oauth signup url as an option

### DIFF
--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -52,6 +52,11 @@ export OAUTH_AUTHORIZE_URL=https://github.com/login/oauth/authorize
 # export OAUTH_AUTHORIZE_URL=https://<your.okta.domain>.com/oauth2/v1/authorize
 # export OAUTH_AUTHORIZE_URL=https://<your.automate.domain>/session/new
 
+# The OAUTH_SIGNUP_URL is the link used to register users with the OAUTH provider
+export OAUTH_SIGNUP_URL=https://github.com/join
+# export OAUTH_SIGNUP_URL=https://bitbucket.org/account/signup/
+# export OAUTH_SIGNUP_URL=https://gitlab.com/users/sign_in#register-pane
+
 # The OAUTH_TOKEN_URL is the *fully qualified* OAuth2 token endpoint
 export OAUTH_TOKEN_URL=https://github.com/login/oauth/access_token
 # export OAUTH_TOKEN_URL=https://bitbucket.org/site/oauth2/access_token

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -89,7 +89,6 @@ provider = "$OAUTH_PROVIDER"
 userinfo_url = "$OAUTH_USERINFO_URL"
 token_url = "$OAUTH_TOKEN_URL"
 redirect_url = "$OAUTH_REDIRECT_URL"
-signup_url = "$OAUTH_SIGNUP_URL"
 client_id = "$OAUTH_CLIENT_ID"
 client_secret = "$OAUTH_CLIENT_SECRET"
 

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -127,6 +127,7 @@ provider = "$OAUTH_PROVIDER"
 client_id = "$OAUTH_CLIENT_ID"
 authorize_url = "$OAUTH_AUTHORIZE_URL"
 redirect_url = "$OAUTH_REDIRECT_URL"
+signup_url = "$OAUTH_SIGNUP_URL"
 
 [nginx]
 max_body_size = "2048m"

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -89,6 +89,7 @@ provider = "$OAUTH_PROVIDER"
 userinfo_url = "$OAUTH_USERINFO_URL"
 token_url = "$OAUTH_TOKEN_URL"
 redirect_url = "$OAUTH_REDIRECT_URL"
+signup_url = "$OAUTH_SIGNUP_URL"
 client_id = "$OAUTH_CLIENT_ID"
 client_secret = "$OAUTH_CLIENT_SECRET"
 


### PR DESCRIPTION
Adds support for the `oauth_signup_url` via the `bldr.env.sample` file.

I wasn't sure how to handle the other auth providers (azure-ad, okta, chef-automate) as users are managed at a different level then a straight forward signup, hence there are no examples in the `bldr.env.sample`.

Thinking how I would set this link if I were using one of the missing providers (azure-ad, okta, chef-automate) I would likely suggest a link to some type of on-boarding documentation.

Signed-off-by: skylerto <skylerclayne@gmail.com>