### PR TITLE
Fix binds for updated builder-api

### DIFF
--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# The endpoint and port for your Postgresql instance
+# Change only if needed
+export POSTGRES_HOST=localhost
+export POSTGRES_PORT=5432
+
 # The endpoint, key and secret for your Minio instance (see README)
 # Change these before the first install if needed
 export MINIO_ENDPOINT=http://localhost:9000

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -70,6 +70,8 @@ EOT
     ARTIFACTORY_API_KEY="none"
     ARTIFACTORY_REPO="habitat-builder-artifact-store"
   fi
+  PG_HOST=${POSTGRES_HOST:-localhost}
+  PG_PORT=${POSTGRES_PORT:-5432}
   cat <<EOT > /hab/svc/builder-api/user.toml
 log_level="error,tokio_core=error,tokio_reactor=error,zmq=error,hyper=error"
 jobsrv_enabled = false
@@ -114,6 +116,8 @@ ttl = 1
 [datastore]
 password = "$PGPASSWORD"
 connection_timeout_sec = 5
+host = "$PG_HOST"
+port = "PG_PORT"
 EOT
 
   mkdir -p /hab/svc/builder-api-proxy
@@ -151,7 +155,7 @@ EOT
 }
 
 start_api() {
-  sudo hab svc load "${BLDR_ORIGIN}/builder-api" --bind memcached:builder-memcached.default --bind datastore:builder-datastore.default --channel "${BLDR_CHANNEL}" --force
+  sudo hab svc load "${BLDR_ORIGIN}/builder-api" --bind memcached:builder-memcached.default --channel "${BLDR_CHANNEL}" --force
 }
 
 start_api_proxy() {


### PR DESCRIPTION
The latest version of builder-api does not have an explicit bind for the datastore, and therefore the provision script needs to be updated.

Signed-off-by: Salim Alam <salam@chef.io>