### PR TITLE
Move Artifactory alpha docs to own page

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The package artifacts will be stored in your Minio instance by default, typicall
 
 If you need to add additional storage, it is recommended that you create a mount at `/hab` and point it to your external storage. This is not required if you already have sufficient free space.
 
-*Note*: If you would prefer to Artifactory instead of Minio for the object storage, please see the [Artifactory](#using-artifactory-as-the-object-store-(alpha)) section below.
+*Note*: If you would prefer to Artifactory instead of Minio for the object storage, please see the [Artifactory](artifactory.md) documentation.
 
 ### Procuring SSL certificate (Recommended)
 
@@ -377,36 +377,6 @@ The `builder-api-proxy` service will log (via Nginx) all access and errors to lo
         endscript
 }
 ```
-
-## Using Artifactory as the object store (Alpha)
-
-If you are interested in using an existing instance of Artifactory as your object store instead of Minio,
-we are providing this capability as an early preview/alpha for testing.
-
-To set this up, you will need to have the following:
-* Know the URL to the Artifactory instance
-* Know (or generate) an API key to authenticate to the instance
-* Create a repo for the Habitat artifacts
-
-Once you have the above, modify the your `bldr.env` based on the same config in `bldr.env.sample` in order to enable Artifactory.
-
-Once you have `bldr.env` updated, you can do an install normally using the `install.sh` script.
-
-After logging into the Depot Web UI and creating your origins, you can try uploading some packages and check your Artifactory instance to ensure that they are present in the repo you specified.
-
-If you run into any issues, please see the Support section below.
-
-### Running a local Artifactory
-
-If you just want to do a quick test, you can also run a local Artifactory instance. In order to do that, you can do the following:
-```
-sudo hab svc load core/artifactory
-```
-This will spin up an Artifactory instance, and you can use the following to log in: http://localhost:8081/artifactory/webapp/#/home
-
-## Support
-
-You can also post any questions or issues on the [Habitat Forum](https://forums.habitat.sh/), on our [Slack channel](https://habitat-sh.slack.com), or file issues directly at the [Github repo](https://github.com/habitat-sh/on-prem-builder/issues).
 
 ## Troubleshooting
 

--- a/artifactory.md
+++ b/artifactory.md
@@ -1,0 +1,29 @@
+# Using Artifactory as the object store (Alpha)
+
+If you are interested in using an existing instance of Artifactory as your object store instead of Minio,
+we are providing this capability as an early preview/alpha for testing.
+
+To set this up, you will need to have the following:
+* Know the URL to the Artifactory instance
+* Know (or generate) an API key to authenticate to the instance
+* Create a repo for the Habitat artifacts
+
+Once you have the above, modify the your `bldr.env` based on the same config in `bldr.env.sample` in order to enable Artifactory.
+
+Once you have `bldr.env` updated, you can do an install normally using the `install.sh` script.
+
+After logging into the Depot Web UI and creating your origins, you can try uploading some packages and check your Artifactory instance to ensure that they are present in the repo you specified.
+
+If you run into any issues, please see the Support section below.
+
+## Running a local Artifactory
+
+If you just want to do a quick test, you can also run a local Artifactory instance. In order to do that, you can do the following:
+```
+sudo hab svc load core/artifactory
+```
+This will spin up an Artifactory instance, and you can use the following to log in: http://localhost:8081/artifactory/webapp/#/home
+
+## Support
+
+You can also post any questions or issues on the [Habitat Forum](https://forums.habitat.sh/), on our [Slack channel](https://habitat-sh.slack.com), or file issues directly at the [Github repo](https://github.com/habitat-sh/on-prem-builder/issues).


### PR DESCRIPTION
The Artifactory content might not be necessary with the installation docs. I'm open to hearing otherwise. This PR moves it onto its own page.
Signed-off-by: kagarmoe <kgarmoe@chef.io>