### PR TITLE
Increase disk requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ The following are minimum requirements for installation/deployment of the Chef H
 * OS should support `systemd` process manager
 * Deployment to bare-metal, VM or container image
 * CPU / RAM should be appropriate for the deployment purpose:
-  * For trial deployments: 2 CPU/4 GB RAM (corresponding to AWS c4.xlarge or better) or better
-  * For production deployments: 16 CPU/32 GB RAM (corresponding to AWS c4.4xlarge) or better
-* Significant free disk space (depends on package storage, which depends on the size of the applications you are building and storing here - plan conservatively. Around 2GB is required for the baseline installation with only the packages required to run the Chef Habitat Builder on-prem services, and another 5GB+ of disk space for the latest versions of core packages)
+  * For trial deployments: 2 CPU/4 GB RAM
+  * For production deployments: 16 CPU/32 GB RAM
+* Significant free disk space. Storage needs will vary, depending primarily on the size of the applications built by Habitat. The baseline Chef Habitat Builder on-prem requires around 2GB to run the Chef Habitat Builder on-prem services and the latest versions of the core packages require another 7GB+ of disk space. However, each package update installs the new package version without deleting existing package versions. We recommend:
+  * For trial deployments: 20 GB disk space
+  * For production deployments: 100 GB disk space
 * Services should be deployed single-node - scale out is not yet supported
 * Outbound network (HTTPS) connectivity to WAN is required for the _initial_ install
 * Inbound network connectivity from LAN (HTTP/HTTPS) is required for internal clients to access the Chef Habitat Builder on-prem

--- a/README.md
+++ b/README.md
@@ -38,12 +38,16 @@ The following are minimum requirements for installation/deployment of the Chef H
 * OS should support `systemd` process manager
 * Deployment to bare-metal, VM or container image
 * CPU / RAM should be appropriate for the deployment purpose:
-  * For trial deployments: 2 CPU/4 GB RAM
-  * For production deployments: 16 CPU/32 GB RAM
-* Significant free disk space. Storage needs will vary, depending primarily on the size of the applications built by Habitat. The baseline Chef Habitat Builder on-prem requires around 2GB to run the Chef Habitat Builder on-prem services and the latest versions of the core packages require another 7GB+ of disk space. However, each package update installs the new package version without deleting existing package versions. We recommend:
-  * For trial deployments: 20 GB disk space
-  * For production deployments: 100 GB disk space
-* Services should be deployed single-node - scale out is not yet supported
+  * 2 CPU/4 GB RAM for trial deployments
+  * 16 CPU/32 GB RAM for production deployments
+* Significant free disk space
+  * 2GB for the baseline Chef Habitat Builder on-prem services
+  * 15GB+ for the latest Chef Habitat Builder core packages
+  * 30GB+ for downloading and expanding the core package bootstrap in the volume containing the `/tmp` directory
+* We recommend:
+  * 20 GB disk space for trial deployments
+  * 100 GB disk space for production deployments
+* Deploy services single-node - scale out is not yet supported
 * Outbound network (HTTPS) connectivity to WAN is required for the _initial_ install
 * Inbound network connectivity from LAN (HTTP/HTTPS) is required for internal clients to access the Chef Habitat Builder on-prem
 * OAuth2 authentication provider (Chef Automate v2, Azure AD, GitHub, GitHub Enterprise, GitLab, Okta and Bitbucket (cloud) have been verified - additional providers may be added on request)


### PR DESCRIPTION
Habitat installs each new package version without removing any existing versions. This PR increases disk space for demonstration and production environments and explains the issue.

For a future reference:

Use `hab pkg uninstall [FLAGS] [OPTIONS] <PKG_IDENT>` to remove unwanted package versions.

```
Safely uninstall a package and dependencies from the local filesystem

USAGE:
    hab pkg uninstall [FLAGS] [OPTIONS] <PKG_IDENT>

FLAGS:
    -d, --dryrun     Just show what would be uninstalled, don't actually do it
        --no-deps    Don't uninstall dependencies
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --exclude <EXCLUDE>...    Identifier of one or more packages that should not be uninstalled. (ex: core/redis, core/busybox-static/1.42.2/21120102031201)

ARGS:
    <PKG_IDENT>    A package identifier (ex: core/redis, core/busybox-static/1.42.2/21120102031201)
```

Signed-off-by: kagarmoe <kgarmoe@chef.io>