### PR TITLE
[on-prem-archive.sh] Fix the install_tools()

### DIFF
--- a/scripts/on-prem-archive.sh
+++ b/scripts/on-prem-archive.sh
@@ -64,15 +64,15 @@ install_tools() {
   do
     echo "Installing ${tool} from Habitat package."
     if [[ "$tool" == "jq" ]]; then
-        HAB_AUTH_TOKEN="" hab pkg install core/jq-static
+        HAB_AUTH_TOKEN="" hab pkg install --channel stable core/jq-static
     elif [[ "$tool" == "aws" ]]; then
-        HAB_AUTH_TOKEN="" hab pkg install core/aws-cli
+        HAB_AUTH_TOKEN="" hab pkg install --channel stable core/aws-cli
     elif [[ "$tool" == "b2sum" ]]; then
-        HAB_AUTH_TOKEN="" hab pkg install core/coreutils
+        HAB_AUTH_TOKEN="" hab pkg install --channel stable core/coreutils
     elif [[ "$tool" == "xzcat" ]]; then
-        HAB_AUTH_TOKEN="" hab pkg install core/xz
+        HAB_AUTH_TOKEN="" hab pkg install --channel stable core/xz
     else
-        HAB_AUTH_TOKEN="" hab pkg install core/"${tool}"
+        HAB_AUTH_TOKEN="" hab pkg install --channel stable core/"${tool}"
     fi
   done
   


### PR DESCRIPTION
### Outstanding Tasks
- [ ] Salim Alam agreed a time for a call to clarify way forward?

### Context
Before doing a 'refresh' of all the base plans, which is the process of re-building all the base-plans when plans like core/glibc and core/gcc are version uplifted, the on-prem-builder must first be pre-seeded with the latest core plans.  First, all core plans are seeded via **on-prem-archive.sh** using ``sudo -E ./scripts/on-prem-archive.sh populate-depot "http://localhost"``.  Next, all the base-plans must be synchronized with the latest 'master' versions and this is done via the same script using ``sudo -E ./scripts/on-prem-archive.sh sync-packages "http://localhost" base-plans``.  

At this stage the synchronization always fails because the script cannot load both core/git and core/jq-static, which are required to perform the synchronization.  The error usually looks something like:

```bash
+ install_tools git curl jq b2sum
+ for tool in '"$@"'
+ echo 'Installing git from Habitat package.'
Installing git from Habitat package.
+ [[ git == \j\q ]]
+ [[ git == \a\w\s ]]
+ [[ git == \b\2\s\u\m ]]
+ [[ git == \x\z\c\a\t ]]
+ HAB_AUTH_TOKEN=
+ hab pkg install core/git
Ø Enabling feature: IGNORE_LOCAL
» Installing core/git
☁ Determining latest version of core/git in the 'refresh-test-001' channel
Ø No releases of core/git exist in the 'refresh-test-001' channel
Ø The following releases were found:
Ø   core/git/2.21.0/20190711155826 in the 'stable' channel
Ø   core/git/2.21.0/20190711155826 in the 'unstable' channel
✗✗✗
✗✗✗ Package not found.
✗✗✗
+ cleanup
+ '[' true ']'
+ echo 'Cleanup skipped.'
Cleanup skipped.
+ echo Done.
Done.
```

The solution proposed is to add **--channel stable** to the installation, which always installs the required core/git and core/jq-static