### PR TITLE
[install.sh] Remove typo causing hab install to fail

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@
 umask 0022
 
 sudo () {
+    # the -E pulls in environment variables like HAB_LICENSE
     [[ $EUID = 0 ]] || set -- command sudo -E "$@"
     "$@"
 }
@@ -24,8 +25,7 @@ fi
 if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
     pushd scripts > /dev/null
     export HAB_LICENSE=accept
-    # use -E to pull in the HAB_LICENSE Env variable
-    sudo -E ./install-hab.sh
+    sudo ./install-hab.sh
     sudo ./hab-sup.service.sh
     sudo ./provision.sh
     popd > /dev/null


### PR DESCRIPTION
Before this fix, the install.sh fails as follows (my debug added):

```bash
+ [[ 0 = 0 ]]
+ -E ./install-hab.sh
./install.sh: line 7: -E: command not found
```

After the fix, the installation of on-prem-builder succeeds showing:

```bash
root@myvm:/hab/builder/on-prem-builder# hab svc status
package                                        type        desired  state  elapsed (s)  pid    group
habitat/builder-memcached/7728/20180929144821  standalone  up       up     498          39864  builder-memcached.default
habitat/builder-api-proxy/8467/20190829194024  standalone  up       up     470          40240  builder-api-proxy.default
habitat/builder-api/8473/20190830141422        standalone  up       up     473          39960  builder-api.default
habitat/builder-minio/7764/20181006010221      standalone  up       up     498          39879  builder-minio.default
habitat/builder-datastore/7809/20181019215440  standalone  up       up     498          39899  builder-datastore.default
root@myvm:/hab/builder/on-prem-builder#
```