### PR TITLE
Remove bogus package

### DIFF
--- a/package_seed_lists/core_full_x86_64-linux_stable
+++ b/package_seed_lists/core_full_x86_64-linux_stable
@@ -615,7 +615,6 @@ core/shield-proxy
 core/snappy
 core/socat
 core/spark
-core/spring-petclinic
 core/sqitch
 core/sqitch_pg
 core/sqlite


### PR DESCRIPTION
Fixes issue #217

The latest stable version of core/spring-petclinic for target
x86_64-linux resolves to core/spring-petclinic/4.2.6/20160824210913

The transitive deps (full version below) include
core/jdk8/8u92/20160620143238 which does not exist on builder.

Removing this dep to fix the issue, but arguably we should not have
'impossible' deps in something in stable.

Full TDEPS for reference:

core/acl/2.2.52/20160612075215
core/attr/2.4.47/20160612075207
core/cacerts/2016.04.20/20160612081125
core/coreutils/8.25/20160729192409
core/gawk/4.1.3/20160729192843
core/gcc-libs/5.2.0/20160612075020
core/glibc/2.22/20160612063629
core/gmp/6.1.0/20160612064724
core/grep/2.22/20160729192643
core/inetutils/1.9.4/20160729192802
core/jdk8/8u92/20160620143238
core/jre8/8u102/20160729190435
core/libcap/2.24/20160612075226
core/linux-headers/4.3/20160612063537
core/mpfr/3.1.4/20160612064810
core/mysql/5.7.14/20160812153521
core/ncurses/6.0/20160612075116
core/openssl/1.0.2h/20160729194249
core/pcre/8.38/20160729192620
core/procps-ng/3.3.11/20160612075316
core/sed/4.2.2/20160612075228
core/tomcat8/8.5.4/20160824210409
core/zlib/1.2.8/20160612064520

Signed-off-by: Mark Anderson <mark@chef.io>