### PR TITLE
Removing deprecated pkgs JDK8 & JRE8 from seed package list

### DIFF
--- a/package_seed_lists/core_deps_x86_64-linux_stable
+++ b/package_seed_lists/core_deps_x86_64-linux_stable
@@ -113,11 +113,9 @@ core/inputproto
 core/iproute2
 core/iptables
 core/jbigkit
-core/jdk8
 core/jemalloc
 core/jfrog-cli
 core/jq-static
-core/jre8
 core/jruby1
 core/json-c
 core/json-glib

--- a/package_seed_lists/core_full_x86_64-linux_stable
+++ b/package_seed_lists/core_full_x86_64-linux_stable
@@ -272,7 +272,6 @@ core/iptables
 core/ipvsadm
 core/jbigkit
 core/jdk7
-core/jdk8
 core/jdk9
 core/jemalloc
 core/jenkins
@@ -283,7 +282,6 @@ core/jo
 core/journalbeat
 core/jq-static
 core/jre7
-core/jre8
 core/jre9
 core/jruby
 core/jruby1

--- a/package_seed_lists/core_full_x86_64-windows_stable
+++ b/package_seed_lists/core_full_x86_64-windows_stable
@@ -48,7 +48,6 @@ core/iis-aspnet4
 core/iis-webserverrole
 core/innounp
 core/jq-static
-core/jre8
 core/lessmsi
 core/lgpo
 core/libarchive


### PR DESCRIPTION
This removes the JDK8 and JRE8 packages which are deprecated and crash the hab pkg download command when included.

Signed-off-by: Steven Marshall <SMarshall@chef.io>