### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following Chef Habitat Builder on-prem functionalities are *NOT* currently a
 
 ## Documentation
 
-The documentation for Builder on-prem is located in the [on-prem-docs](on-prem-docs/README.md) directory. For your convenience, you can serve the documentation locally from that directory by installing the dependencies and running the `hugo serve` command.
+The documentation for Builder on-prem is located in the [on-prem-docs directory](on-prem-docs/README.MD). For your convenience, you can serve the documentation locally from that directory by installing the dependencies and running the `hugo serve` command.
 
 ### Index
 


### PR DESCRIPTION
the on-prem-builder docs directory link was bad because of the capitalized extension, not sure if youd rather fix the extension?
also made the link text a bit more accessible

Signed-off-by: susanev <susan.ra.evans@gmail.com>