### PR TITLE
Add chef official packages after 0.18.0 release

### DIFF
--- a/package_seed_lists/effortless_x86_64-linux_stable
+++ b/package_seed_lists/effortless_x86_64-linux_stable
@@ -1,4 +1,5 @@
 chef/chef-client
+chef/chef-infra-client
 chef/inspec
 chef/scaffolding-chef-infra
 chef/scaffolding-chef-inspec

--- a/package_seed_lists/effortless_x86_64-windows_stable
+++ b/package_seed_lists/effortless_x86_64-windows_stable
@@ -1,5 +1,7 @@
 chef/scaffolding-chef-infra
 chef/scaffolding-chef-inspec
+chef/chef-infra-client
+chef/inspec
 effortless/audit-baseline
 effortless/config-baseline
 stuartpreston/chef-client 

--- a/package_seed_lists/effortless_x86_64-windows_stable
+++ b/package_seed_lists/effortless_x86_64-windows_stable
@@ -4,6 +4,3 @@ chef/chef-infra-client
 chef/inspec
 effortless/audit-baseline
 effortless/config-baseline
-stuartpreston/chef-client 
-stuartpreston/inspec      
-stuartpreston/chef-client-detox 


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

This is an update to the stable seed list for effortless that adds the new official Chef Infra Client and Chef InSpec client for both Windows and Linux