### PR TITLE
Correct links to bootstrap-core

### DIFF
--- a/on-prem-docs/builder-automate.md
+++ b/on-prem-docs/builder-automate.md
@@ -199,4 +199,4 @@ If necessary, rename the custom certificates cert file as `ssl-certificate.crt` 
 
 ## Next Steps
 
-[Bootstrap Core Origin](/docs/bootstrap-core)
+[Bootstrap Core Origin](./bootstrap-core.md)

--- a/on-prem-docs/builder-oauth.md
+++ b/on-prem-docs/builder-oauth.md
@@ -173,4 +173,4 @@ At that point you should be able to log in using your configured OAuth provider.
 
 ## Next Steps
 
-[Bootstrap Core Origin](/docs/bootstrap-core)
+[Bootstrap Core Origin](/docs/bootstrap-core.md)


### PR DESCRIPTION
This corrects links to the bootstrap-core documentation from the auth configuration documentation. 
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>