### PR TITLE
enable installation with S3 and/or RDS backends

### DIFF
--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-# The endpoint and port for your Postgresql instance
+# Only enable and set these if using RDS instead of a local PostgreSQL instance
+# Migrations from local PostgreSQL to RDS are curently not supported.
+#export RDS_ENABLED=false
+#export RDS_USER=hab
+#export RDS_PASSWORD=hab
+
+# The endpoint and port for your Postgresql or RDS instance
 # Change only if needed
 export POSTGRES_HOST=localhost
 export POSTGRES_PORT=5432
@@ -11,6 +17,14 @@ export MINIO_ENDPOINT=http://localhost:9000
 export MINIO_BUCKET=habitat-builder-artifact-store.local
 export MINIO_ACCESS_KEY=depot
 export MINIO_SECRET_KEY=password
+
+# If you'd like to use AWS S3 instead of Minio,
+# set S3_ENABLED=true and change the other S3 associated variables appropriately.
+export S3_ENABLED=false
+export S3_REGION=us-west-2
+export S3_BUCKET=habitat-builder-artifact-store.local
+export S3_ACCESS_KEY=depotaccesskey
+export S3_SECRET_KEY=depotsecretkey
 
 # If you'd like to use Arifactory instead of Minio, uncomment
 # and set the following variables appropriately.


### PR DESCRIPTION
Officially support rollout with RDS or S3 backends.

Signed-off-by: Jeremy J. Miller <jm@chef.io>