### PR TITLE
enables frontend scaleout

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,4 @@ The documentation for Builder on-prem is located in the [on-prem-docs](on-prem-d
 1. [Managing the Builder On-Prem Minio Installation](on-prem-docs/minio.md)
 1. [Using Artifactory with Builder On-Prem](on-prem-docs/artifactory.md)
 1. [High Availability / Disaster Recovery](on-prem-docs/warm-spare.md)
+1. [Scaling Frontends](on-prem-docs/scaling.md)

--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -86,6 +86,7 @@ export OAUTH_TOKEN_URL=https://github.com/login/oauth/access_token
 
 # The OAUTH_REDIRECT_URL is the registered OAuth2 redirect
 # IMPORTANT: If SSL is enabled, the redirect URL should be https
+# IF SCALING FRONTEND, POINT THIS AT YOUR LOAD BALANCER
 export OAUTH_REDIRECT_URL=http://localhost/
 
 # The OAUTH_CLIENT_ID is the registered OAuth2 client id

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ cat NOTICE
 echo
 
 license="${HAB_LICENSE:-}"
-export response
+declare response
 
 if [ "$license" == "accept" ] || [ "$license" == "accept-no-persist" ]; then
   echo "INFO: Detected HAB_LICENSE=${HAB_LICENSE}"

--- a/install.sh
+++ b/install.sh
@@ -12,9 +12,12 @@ cat NOTICE
 echo
 
 license="${HAB_LICENSE:-}"
+export response
 
 if [ "$license" == "accept" ] || [ "$license" == "accept-no-persist" ]; then
-  read -r -p "Continue with installation? [y/N] " response
+  echo "INFO: Detected HAB_LICENSE=${HAB_LICENSE}"
+  echo "Continuing with installation"
+  response="y"
 else
   cat LICENSE-NOTICE
   echo
@@ -27,6 +30,6 @@ if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
     export HAB_LICENSE=accept
     sudo ./install-hab.sh
     sudo ./hab-sup.service.sh
-    sudo ./provision.sh
+    sudo ./provision.sh "$@"
     popd > /dev/null
 fi

--- a/on-prem-docs/scaling.md
+++ b/on-prem-docs/scaling.md
@@ -1,0 +1,28 @@
+# Front-end Scaling
+With any tiered or HA deployment of the builder services you'll likely want to horizontally scale your front-end nodes. The most common deployment pattern for this usecase is a pool of front-end nodes fronted by a load-balancer.
+
+## Deploying New Front-ends
+The on-prem-builder install.sh script now supports scaling front-end nodes as a deployment pattern. It is require that new front-ends be deployed on a separate compute from your initial on-prem deployment. Similarly to Chef Automate's bootstrap pattern the on-prem builder install script can generate a bootstrap bundle which is used to simplify the deployment of new front-ends.
+
+### Create and update bldr-frontend.env
+The bldr.env file for your single on-prem builder node contains most of the information required to bootstrap a new front-end and will be used during the installation process. However, some configuration will  need to change.
+
+First, you'll need to copy your `bldr.env` file to `bldr-frontend.env`.
+
+In the case that your on-prem-builder cluster is backed by cloud services, you will only need to update the value of `OAUTH_REDIRECT_URL`. When running multiple front-end instances this value should be pointed to your load-balancer. 
+
+In the case that you are _not_ backing your cluster with cloud services you will need to update the values of `OAUTH_REDIRECT_URL`, `POSTGRES_HOST`, and `MINIO_ENDPOINT`.
+
+1. Copy your `on-prem-builder/bldr.env` to `bldr-frontend.env`
+1. Update the contents `bldr-frontend.env` to match your deployment pattern
+
+### Generate & send bootstrap_bundle.tar
+Once the bldr-frontend.env file's contents have been updated with appropriate information we should be ready to generate the bootstrap bundle. After creation, we'll send it to the target node we intend to run the front-end service on.
+
+1. Generate a bootstrap bundle `./install.sh --generate-bootstrap`
+1. Copy the generated `/hab/bootstrap_bundle.tar` to the same path on the new frontend node
+
+### Install frontend
+1. Run the front-end install script from the new front-end node `./install.sh --install-frontend`
+
+

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -299,8 +299,8 @@ generate_frontend_bootstrap_bundle() {
       cp ../bldr-frontend.env /hab/bootstrap_bundle/configs
     else
         echo "ERROR: ./bldr-frontend.env does not exist!"
-        echo "hint: If using cloud services (RDS/S3) copy ./bldr.env to ./bldr-frontend.env and update"
-        echo "APP_URL and OAUTH_REDIRECT_URL. Otherwise copy and update entries for POSTGRES_HOST, "
+        echo "hint: If using cloud services (RDS/S3) copy ./bldr.env to ./bldr-frontend.env and"
+        echo "update OAUTH_REDIRECT_URL. Otherwise copy and update entries for POSTGRES_HOST, "
         echo "MINIO_ENDPOINT and OAUTH_REDIRECT_URL."
         exit 1 
     fi

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -293,18 +293,30 @@ generate_frontend_bootstrap_bundle() {
 
 start_frontend_from_bootstrap_bundle() {
   if [ ! -f /hab/bootstrap_bundle.tar ]; then
-    echo "ERROR: /hab/bootstrap_bundle.tar does not exist! hint: run './install.sh --gen-bootstrap'"
+    echo "ERROR: /hab/bootstrap_bundle.tar does not exist!"
+    echo "hint: run './install.sh --generate-bootstrap'"
     echo "from any other functioning node running the builder-api service"
     exit 1
   fi
   if hab svc status habitat/builder-api >/dev/null 2>&1; then
     echo "ERROR: ${BLDR_ORIGIN}/builder-api is already running on this node!"
     echo "This script is only intended to be run on nodes that do not already"
-    echo "have builder-api installed or configured."
+    echo "have builder-api installed or configured. This process could be"
+    echo "data destructive if performed on a pre-existing builder api node."
     echo
     echo "To proceed, unload ${BLDR_ORIGIN}/builder-api and its svc directory."
     exit 1
   fi
+
+  if hab svc status habitat/builder-datastore >/dev/null 2>&1; then
+    echo "ERROR: ${BLDR_ORIGIN}/builder-datastore is running on this node!"
+    echo "This script is only intended to be run on nodes that do not already"
+    echo "have builder services installed, --install-frontend should not be used "
+    echo "on a node running habitat/builder-datastore"
+    echo
+    exit 1
+  fi
+
 
   echo "Extracting bootstrap bundle from /hab/bootstrap_bundle.tar"
   tar xvf /hab/bootstrap_bundle.tar -C /

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+
+echo "WARNING: This will uninstall all Builder Services. All data will be preserved."
+read -p "Proceed? [y|n]" -n 1 -r
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  exit 1
+fi
+echo
+echo "Uninstalling.."
 systemctl stop hab-sup
 rm -rf /hab/sup/default/specs/builder-*
 rm -rf /hab/pkgs/habitat
+echo


### PR DESCRIPTION
Enable a deployment pattern of horizontally scaling out front-end API nodes via the `install.sh` script.

Signed-off-by: Jeremy J. Miller <jm@chef.io>