### PR TITLE
Improve frontend-install with peering

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ The following are minimum requirements for installation/deployment of the Chef H
 * Chef recommends:
   * 50 GB disk space for trial deployments
   * 100 GB disk space for production deployments
-* Deploy services single-node - scale out is not yet supported
 * Outbound network (HTTPS) connectivity to WAN is required for the _initial_ install
 * Inbound network connectivity from LAN (HTTP/HTTPS) is required for internal clients to access the Chef Habitat Builder on-prem
 * OAuth2 authentication provider (Chef Automate v2, Azure AD, GitHub, GitHub Enterprise, GitLab, Okta and Bitbucket (cloud) have been verified - additional providers may be added on request)

--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -103,6 +103,12 @@ export HAB_BLDR_URL=https://MY_ON_PREM_URL/
 # From the Automate CLI use
 # export HAB_BLDR_URL=https://MY_ON_PREM_URL/bldr/v1/
 
+# Modify if you are splitting frontend and backend on separate nodes
+# If so, this should include a --peer argument for each builder IP or hostname
+# including all frontend and backend nodes.
+# For example: export HAB_BLDR_PEER_ARG="--peer host1 --peer host2 --peer host3"
+export HAB_BLDR_PEER_ARG=""
+
 # Help us make Habitat better! Opt into analytics by changing the ANALYTICS_ENABLED
 # setting below to true, then optionally provide your company name. (Analytics is
 # disabled by default. See our privacy policy at https://www.habitat.sh/legal/privacy-policy/.)

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,19 @@ sudo () {
     "$@"
 }
 
+check_envfile() {
+if [ -f ../bldr.env ]; then
+  # shellcheck disable=SC1091
+  source ../bldr.env
+elif [ -f /vagrant/bldr.env ]; then
+  # shellcheck disable=SC1091
+  source /vagrant/bldr.env
+else
+  echo "ERROR: bldr.env file is missing!"
+  exit 1
+fi
+}
+
 cat NOTICE
 echo
 
@@ -29,6 +42,7 @@ if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
     pushd scripts > /dev/null
     export HAB_LICENSE=accept
     sudo ./install-hab.sh
+    check_envfile
     sudo ./hab-sup.service.sh
     sudo ./provision.sh "$@"
     popd > /dev/null

--- a/on-prem-docs/getting-started.md
+++ b/on-prem-docs/getting-started.md
@@ -25,7 +25,6 @@ The following are minimum requirements for installation/deployment of the Chef H
 * We recommend:
   * 50 GB disk space for trial deployments
   * 100 GB disk space for production deployments
-* Deploy services single-node - scale out is not yet supported
 * Outbound network (HTTPS) connectivity to WAN is required for the _initial_ install
 * Inbound network connectivity from LAN (HTTP/HTTPS) is required for internal clients to access the Chef Habitat Builder on-prem
 * OAuth2 authentication provider (Chef Automate v2, Azure AD, GitHub, GitHub Enterprise, GitLab, Okta and Bitbucket (cloud) have been verified - additional providers may be added on request)

--- a/on-prem-docs/scaling.md
+++ b/on-prem-docs/scaling.md
@@ -2,27 +2,27 @@
 With any tiered or HA deployment of the builder services you'll likely want to horizontally scale your front-end nodes. The most common deployment pattern for this usecase is a pool of front-end nodes fronted by a load-balancer.
 
 ## Deploying New Front-ends
-The on-prem-builder install.sh script now supports scaling front-end nodes as a deployment pattern. It is require that new front-ends be deployed on a separate compute from your initial on-prem deployment. Similarly to Chef Automate's bootstrap pattern the on-prem builder install script can generate a bootstrap bundle which is used to simplify the deployment of new front-ends.
+The on-prem-builder install.sh script now supports scaling front-end nodes as a deployment pattern. It is required that new front-ends be deployed on a separate compute from your initial on-prem deployment. Since builder services will now need to communicate accross your network between the frontend and backend nodes, you must open the folowing ports to these nodes in order to guarantee your on-prem builder properly functions:
 
-### Create and update bldr-frontend.env
-The bldr.env file for your single on-prem builder node contains most of the information required to bootstrap a new front-end and will be used during the installation process. However, some configuration will  need to change.
+* TCP 9638 - Habitat configuration gossip
+* UDP 9638 - Habitat configuration gossip
+* TCP 9636 - Builder API HTTP
+* TCP 5432 - postgresql
+* TCP 9000 - minio
+* TCP 11211 - memcached
 
-First, you'll need to copy your `bldr.env` file to `bldr-frontend.env`.
+### Create and update bldr.env
+The bldr.env file for your single on-prem builder node contains most of the information required to bootstrap a new front-end and will be used during the installation process. However, some configuration will need to change.
 
-In the case that your on-prem-builder cluster is backed by cloud services, you will only need to update the value of `OAUTH_REDIRECT_URL`. When running multiple front-end instances this value should be pointed to your load-balancer. 
+In the case that your on-prem-builder cluster is backed by cloud services, you will need to update the value of `OAUTH_REDIRECT_URL`. When running multiple front-end instances this value should be pointed to your load-balancer. 
 
 In the case that you are _not_ backing your cluster with cloud services you will need to update the values of `OAUTH_REDIRECT_URL`, `POSTGRES_HOST`, and `MINIO_ENDPOINT`.
 
-1. Copy your `on-prem-builder/bldr.env` to `bldr-frontend.env`
-1. Update the contents `bldr-frontend.env` to match your deployment pattern
+Additionally, you will need to edit (or create if it is not alreadu present) `HAB_BLDR_PEER_ARG` to include all frontend and backend nodes hosting builder services. The format is as follows:
 
-### Generate & send bootstrap_bundle.tar
-Once the bldr-frontend.env file's contents have been updated with appropriate information we should be ready to generate the bootstrap bundle. After creation, we'll send it to the target node we intend to run the front-end service on.
-
-1. Generate a bootstrap bundle `./install.sh --generate-bootstrap`
-1. Copy the generated `/hab/bootstrap_bundle.tar` to the same path on the new frontend node
+```
+--peer host1 --peer host2 --peer host3
+```
 
 ### Install frontend
-1. Run the front-end install script from the new front-end node `./install.sh --install-frontend`
-
-
+Run the front-end install script from each new front-end node `./install.sh --install-frontend`

--- a/scripts/hab-sup.service.sh
+++ b/scripts/hab-sup.service.sh
@@ -36,7 +36,7 @@ Description=Habitat Supervisor
 
 [Service]
 ExecStartPre=/bin/bash -c "/bin/systemctl set-environment SSL_CERT_FILE=${SSL_CERT_FILE}"
-ExecStart=/bin/hab sup run
+ExecStart=/bin/hab sup run ${HAB_BLDR_PEER_ARG}
 ExecStop=/bin/hab sup term
 KillMode=process
 LimitNOFILE=65535


### PR DESCRIPTION
Closes #254 

This PR provides the following enhancements to `--frontend-install`:
* Allows the user to peer al builder nodes. This will allow the memcached services to distribute the cache and also allow the builder-api-proxy service to load balance calls to builder-api.
* Eliminate the need to create a bootstrap_bundle. Because the nodes are peered, the data and files in the bundle can be gossiped to the other nodes.
* Updates all docs mentioning scale out to align with this functionality