### PR TITLE
Updated Documentation

### DIFF
--- a/bldr.env.sample
+++ b/bldr.env.sample
@@ -99,7 +99,7 @@ export OAUTH_CLIENT_SECRET=0123456789abcdef0123456789abcdef01234567
 # Modify these only if there is a specific need, otherwise leave as is
 export BLDR_CHANNEL=on-prem-stable
 export BLDR_ORIGIN=habitat
-export HAB_BLDR_URL=https://MY_ON_PREM_URL/
+export HAB_BLDR_URL=https://bldr.habitat.sh/
 # From the Automate CLI use
 # export HAB_BLDR_URL=https://MY_ON_PREM_URL/bldr/v1/
 

--- a/on-prem-docs/bootstrap-core.md
+++ b/on-prem-docs/bootstrap-core.md
@@ -12,7 +12,7 @@ Next, generate a Personal Access Token for bootstrapping the `core` packages, as
 
 Select your Gravatar icon on the top right corner of the Chef Habitat Builder on-prem web page, and then select **Profile**. This will take you to a page where you can generate your access token. Make sure to save it securely.
 
-## Bootstrap Builder with Habitat Packages (**New**)
+## Bootstrap Builder with Habitat Packages
 
 Chef Habitat Builder on-prem has no pre-installed package sets. You must populate your Builder instance by uploading packages.
 With Habitat *0.88.0*, two new commands were introduced to assist in bootstrapping an on-prem Builder instance with a set of stable packages:
@@ -46,51 +46,6 @@ The following section illustrates the steps required to bootstrap the on-prem Bu
     export HAB_AUTH_TOKEN=<your_on-prem_Builder_instance_token>
     hab pkg bulkupload --url https://your-builder.tld --channel stable builder_bootstrap/
     ```
-
-## Bootstrap `core` packages (**Deprecated**)
-
-*Important*: This methodology is now deprecated in favor of the download/bulkupload flow described above.
-
-*Important*: Create a `core` origin before starting this process. The process will fail without first having a `core` origin.
-
-Chef Habitat Builder on-prem has no pre-installed packages. To bootstrap a set of stable `core` origin packages (refer to the [core-plans repo](https://github.com/habitat-sh/core-plans)), you can do the following:
-
-1. Export your Personal Access Token as `HAB_AUTH_TOKEN` to your environment
-
-    ```bash
-    export HAB_AUTH_TOKEN=<your token>
-    ```
-
-1. Run the population script, passing the root URL of your new Chef Habitat Builder on-prem as the last argument (Replace `http` with `https` in the URL if SSL is enabled)
-
-    ```bash
-    sudo -E ./scripts/on-prem-archive.sh populate-depot http://${BUILDER_HOSTNAME_OR_IP}`
-    ```
-
-This is quite a lengthy process, so be patient. It will download a *large* (~ 14GB currently) archive of the latest stable core plans, and then install them to your Chef Habitat Builder on-prem.
-
-Please ensure that you have plenty of free disk space available for hosting the `core` packages as well as for managing your own packages. Updated packages install without deleting any existing packages, so plan disk space accordingly.
-
-## Synchronizing 'core' packages from an upstream (**Deprecated**)
-
-*Important*: This methodology is now deprecated in favor of the download/bulkupload flow described above.
-
-*Important*: Create a `core` origin before starting this process. The process will fail without first having a `core` origin.
-
-It is possible to also use the 'on-prem-archive.sh' script to synchronize the Chef Habitat Builder on-prem using the public Chef Habitat Builder site as an 'upstream'.
-
-This allows new stable core packages from the upstream to get created in the Chef Habitat Builder on-prem instance automatically.
-
-If your Chef Habitat Builder on-prem instance will have continued outgoing internet connectivity, you may wish to periodically run the script to check for updates.
-
-1. Export your Personal Access Token as `HAB_AUTH_TOKEN` to your environment (e.g, `export HAB_AUTH_TOKEN=<your token>`)
-1. `sudo -E ./scripts/on-prem-archive.sh sync-packages http://${BUILDER_HOSTNAME_OR_IP} base-plans`, passing the root URL of your new Chef Habitat Builder on-prem as the last argument. Replace `http` with `https` in the URL if SSL is enabled.
-
-The 'base-plans' parameter restricts the sync to a smaller subset of the core packages. If you wish to synchronize all core packages, omit the 'base-plans' parameter from the script. Note that it will take much longer for the synchronization of all packages. Generally, it will only take a few minutes for base packages to synchronize.
-
-You can also run the sync-packages functionality to initially populate the local Chef Habitat Builder on-prem.
-
-*NOTE*: This functionality is being provided as an alpha - please log any issues found in the on-prem-builder repo.
 
 ## Configuring a user workstation
 

--- a/on-prem-docs/builder-oauth.md
+++ b/on-prem-docs/builder-oauth.md
@@ -173,4 +173,4 @@ At that point you should be able to log in using your configured OAuth provider.
 
 ## Next Steps
 
-[Bootstrap Core Origin](/docs/bootstrap-core.md)
+[Bootstrap Core Origin](./bootstrap-core.md)

--- a/on-prem-docs/scaling.md
+++ b/on-prem-docs/scaling.md
@@ -18,7 +18,7 @@ In the case that your on-prem-builder cluster is backed by cloud services, you w
 
 In the case that you are _not_ backing your cluster with cloud services you will need to update the values of `OAUTH_REDIRECT_URL`, `POSTGRES_HOST`, and `MINIO_ENDPOINT`.
 
-Additionally, you will need to edit (or create if it is not alreadu present) `HAB_BLDR_PEER_ARG` to include all frontend and backend nodes hosting builder services. The format is as follows:
+Additionally, you will need to edit (or create if it is not already present) `HAB_BLDR_PEER_ARG` to include all frontend and backend nodes hosting builder services. The format is as follows:
 
 ```
 --peer host1 --peer host2 --peer host3

--- a/on-prem-docs/scaling.md
+++ b/on-prem-docs/scaling.md
@@ -14,9 +14,11 @@ The on-prem-builder install.sh script now supports scaling front-end nodes as a 
 ### Create and update bldr.env
 The bldr.env file for your single on-prem builder node contains most of the information required to bootstrap a new front-end and will be used during the installation process. However, some configuration will need to change.
 
-In the case that your on-prem-builder cluster is backed by cloud services, you will need to update the value of `OAUTH_REDIRECT_URL`. When running multiple front-end instances this value should be pointed to your load-balancer. 
+Update the values of `OAUTH_REDIRECT_URL`, `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` as per the on-premise OAuth2 provider.
 
-In the case that you are _not_ backing your cluster with cloud services you will need to update the values of `OAUTH_REDIRECT_URL`, `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET` , `POSTGRES_HOST`, and `MINIO_ENDPOINT`.
+In the case that your on-prem-builder cluster is backed by cloud services and you are running multiple front-end instances `OAUTH_REDIRECT_URL` should be pointed to your load-balancer. 
+
+In the case that you are _not_ backing your cluster with cloud services you will need to update the values of `POSTGRES_HOST`, and `MINIO_ENDPOINT`.
 
 Additionally, you will need to edit (or create if it is not already present) `HAB_BLDR_PEER_ARG` to include all frontend and backend nodes hosting builder services. The format is as follows:
 

--- a/on-prem-docs/scaling.md
+++ b/on-prem-docs/scaling.md
@@ -16,7 +16,7 @@ The bldr.env file for your single on-prem builder node contains most of the info
 
 In the case that your on-prem-builder cluster is backed by cloud services, you will need to update the value of `OAUTH_REDIRECT_URL`. When running multiple front-end instances this value should be pointed to your load-balancer. 
 
-In the case that you are _not_ backing your cluster with cloud services you will need to update the values of `OAUTH_REDIRECT_URL`, `POSTGRES_HOST`, and `MINIO_ENDPOINT`.
+In the case that you are _not_ backing your cluster with cloud services you will need to update the values of `OAUTH_REDIRECT_URL`, `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET` , `POSTGRES_HOST`, and `MINIO_ENDPOINT`.
 
 Additionally, you will need to edit (or create if it is not already present) `HAB_BLDR_PEER_ARG` to include all frontend and backend nodes hosting builder services. The format is as follows:
 

--- a/on-prem-docs/separating-backend-services.md
+++ b/on-prem-docs/separating-backend-services.md
@@ -6,6 +6,11 @@ You can now have a setup where the postgresql service runs on one node and minio
 ## Pre-requisites
 The bldr.env file for your single on-prem builder node contains most of the information required setup minio and postgresql on it and will be used during the installation process.
 
+Modify your `bldr.env` based on the same config in `bldr.env.sample`
+```bash
+cp bldr.env.sample bldr.env
+```
+
 For the setting up the minio server on a separate node, make sure that `S3_ENABLED` and `ARTIFACTORY_ENABLED` in the bldr.env are set to `false`.
 This must be ensured as minio server can not be used if you are using S3 or Artifactory directly.
 
@@ -44,9 +49,7 @@ Run the postgresql install script from the the node
 ```
 
 ### Connecting to Datastore node
-The bldr.env of the nodes have to modified in order to connect to the datastore running on a different node. Following are the fields that have to be updated onto the nodes that are trying to connect to the Datastore:
+The value of `POSTGRES_HOST` in the bldr.env file has to be mapped to the Node where the Datastore service is running in order to connect to it.
 
-* `PG_EXT_ENABLED` has to be set to true
-* `POSTGRES_HOST` has to be mapped to the Node where the Datastore is running
 
 #### NOTE: Please refer this [documentat](./scaling.md) for setting up and scaling the front end.

--- a/on-prem-docs/separating-backend-services.md
+++ b/on-prem-docs/separating-backend-services.md
@@ -52,4 +52,4 @@ Run the postgresql install script from the the node
 The value of `POSTGRES_HOST` in the bldr.env file has to be mapped to the Node where the Datastore service is running in order to connect to it.
 
 
-#### NOTE: Please refer this [documentat](./scaling.md) for setting up and scaling the front end.
+#### NOTE: Please refer this [document](./scaling.md) for setting up and scaling the front end.

--- a/on-prem-docs/separating-backend-services.md
+++ b/on-prem-docs/separating-backend-services.md
@@ -1,0 +1,52 @@
+# Separating Backend Services (minio/postgresql)
+
+The on-prem-builder install.sh script now supports separation of the backend components i.e datastore and minio server onto different nodes.
+You can now have a setup where the postgresql service runs on one node and minio runs on another. Both can be designed to communicate to one another and to a third or more nodes running the front-end services. 
+
+## Pre-requisites
+The bldr.env file for your single on-prem builder node contains most of the information required setup minio and postgresql on it and will be used during the installation process.
+
+For the setting up the minio server on a separate node, make sure that `S3_ENABLED` and `ARTIFACTORY_ENABLED` in the bldr.env are set to `false`.
+This must be ensured as minio server can not be used if you are using S3 or Artifactory directly.
+
+For the setting up the datastore on a separate node, make sure that `PG_EXT_ENABLED` in the bldr.env is set to `false`.
+This must be ensured as the Datastore node cannot have externally hosted PostgreSQL(RDS, Azure Database for PostgreSql etc).
+
+Please refer our [scaling documentation](./scaling.md#deploying-new-front-ends) for detailed information regarding opening the ports.
+
+Additionally, you will need to edit (or create if it is not already present) `HAB_BLDR_PEER_ARG` to include all frontend and backend nodes hosting builder services. The format is as follows:
+
+```
+--peer host1 --peer host2 --peer host3
+```
+
+## Separating MinIO Server
+MinIO is an open source object storage server. Chef Habitat Builder on-prem uses Minio to store habitat artifacts (.harts).
+
+### Install Minio
+Run the minio install script from the new node that will run the minio service to store all the artifacts
+```bash
+./install.sh --install-minio
+```
+
+### Connecting to Minio server node
+Now that your Minio server is up and running on its own node, it is crucial to know how to connect your other backend and frontend nodes to it.
+The `MINIO_ENDPOINT` in the bldr.env file has to be mapped to the Node where the Minio server is running.
+You can then access the Minio UI using the `MINIO_ENDPOINT` URL.
+
+## Separating postgresql
+The backend datastore can also be setup to run on a separate node.
+
+### Install postgresql
+Run the postgresql install script from the the node
+```bash
+./install.sh --install-postgresql
+```
+
+### Connecting to Datastore node
+The bldr.env of the nodes have to modified in order to connect to the datastore running on a different node. Following are the fields that have to be updated onto the nodes that are trying to connect to the Datastore:
+
+* `PG_EXT_ENABLED` has to be set to true
+* `POSTGRES_HOST` has to be mapped to the Node where the Datastore is running
+
+#### NOTE: Please refer this [documentat](./scaling.md) for setting up and scaling the front end.

--- a/on-prem-docs/separating-backend-services.md
+++ b/on-prem-docs/separating-backend-services.md
@@ -1,12 +1,17 @@
 # Separating Backend Services (minio/postgresql)
 
 The on-prem-builder install.sh script now supports separation of the backend components i.e datastore and minio server onto different nodes.
-You can now have a setup where the postgresql service runs on one node and minio runs on another. Both can be designed to communicate to one another and to a third or more nodes running the front-end services. 
+You can now have a setup where the postgresql service runs on one node and minio runs on another. Both can be configured to communicate with other nodes running the front-end services.
 
 ## Pre-requisites
-The bldr.env file for your single on-prem builder node contains most of the information required setup minio and postgresql on it and will be used during the installation process.
+The bldr.env file contains all of the information required to setup minio and postgresql and will be used during the installation process.
 
-Modify your `bldr.env` based on the same config in `bldr.env.sample`
+If your node has already had an older instance of on-prem components on it, run the following to clean up your environment.
+```bash
+./uninstall.sh
+```
+
+Modify the `bldr.env.sample` file and save it to `bldr.env` .
 ```bash
 cp bldr.env.sample bldr.env
 ```
@@ -35,7 +40,7 @@ Run the minio install script from the new node that will run the minio service t
 ```
 
 ### Connecting to Minio server node
-Now that your Minio server is up and running on its own node, it is crucial to know how to connect your other backend and frontend nodes to it.
+Now that your Minio server is up and running on its own node, it is crucial to know how to connect your frontend nodes to it.
 The `MINIO_ENDPOINT` in the bldr.env file has to be mapped to the Node where the Minio server is running.
 You can then access the Minio UI using the `MINIO_ENDPOINT` URL.
 
@@ -49,7 +54,7 @@ Run the postgresql install script from the the node
 ```
 
 ### Connecting to Datastore node
-The value of `POSTGRES_HOST` in the bldr.env file has to be mapped to the Node where the Datastore service is running in order to connect to it.
+The value of `POSTGRES_HOST` in the bldr.env file on the front end nodes must be mapped to the Node where the Datastore service is running in order to connect to it.
 
 
 #### NOTE: Please refer this [document](./scaling.md) for setting up and scaling the front end.

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -319,7 +319,7 @@ install_frontend() {
 install_postgresql() {
   #Check if externally hosted PostgreSQL is enabled
   if [ "${PG_EXT_ENABLED:-false}" = "true" ]; then
-    echo "ERROR: --install-postgresql can not not be used if you are using"
+    echo "ERROR: --install-postgresql can not be used if you are using"
     echo "externally hosted PostgreSQL(RDS, Azure Database for PostgreSql etc)."
     echo "Set PG_EXT_ENABLED=false to fix this error."
     echo
@@ -337,7 +337,7 @@ install_postgresql() {
 install_minio() {
   #Check if using S3 or Artifactory directly
   if [ "${S3_ENABLED:-false}" = "true" ] || [ "${ARTIFACTORY_ENABLED:-false}" = "true" ]; then
-    echo "ERROR: --install-minio can not not be used if you are using S3 or Artifactory directly."
+    echo "ERROR: --install-minio can not be used if you are using S3 or Artifactory directly."
     echo "Set S3_ENABLED=false and ARTIFACTORY_ENABLED=false to fix this error."
     echo
     return


### PR DESCRIPTION
Closes https://github.com/habitat-sh/on-prem-builder/issues/256

Added Documentation to explain how to use the feature of separating front-end and back-end services.
Addresses https://github.com/habitat-sh/on-prem-builder/issues/254 and https://github.com/habitat-sh/on-prem-builder/issues/255 .

Signed-off-by: dikshagupta1 <diksha.gupta@progress.com>