### PR TITLE
Add documentation guide on rotating builder SSL certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The documentation for Builder on-prem is located in the [on-prem-docs](on-prem-d
 1. [Using Artifactory with Builder On-Prem](on-prem-docs/artifactory.md)
 1. [High Availability / Disaster Recovery](on-prem-docs/warm-spare.md)
 1. [Scaling Frontends](on-prem-docs/scaling.md)
+1. [SSL Certificate Rotation](on-prem-docs/ssl-cert-rotation.md)
 
 #### Data Migration to Chef Automate deployed Builder
 

--- a/on-prem-docs/ssl-cert-rotation.md
+++ b/on-prem-docs/ssl-cert-rotation.md
@@ -1,0 +1,31 @@
+# Updating the SSL certs used by Builder's web interface.
+
+## Understanding where the Builder certs live
+
+Chef Habitat Builder's web front-end is hosted via NGINX running via the `habitat/builder-api-proxy` service.  The NGINX config file for the api-proxy service tells NGINX to load SSL certificate and key from files located at `/hab/svc/builder-api-proxy/files`.  The certificate and key names **_need_** to be named `ssl-certificate.crt` and `ssl-certificate.key`.  The `files` directory is managed via the `hab file upload` functionality.  So in order to change these certificates permanently, you need to upload the files through hab, and then restart the proxy.
+
+## Rotating the SSL certificate and key
+
+There's really a few simple commands to run in order to rotate your key.
+
+First, rename your cert-chain and key file to the names required by the builder-api-proxy service.
+
+```shell
+cp <CERTIFICATE_CHAIN_FILENAME> ssl-certificate.crt
+cp <CERTIFICATE_KEY_FILENAME> ssl-certificate.key
+```
+
+Then upload the certificate and key files to the builder service.
+
+```shell
+hab file upload "builder-api-proxy.default" "$(date +%s)" ./ssl-certificate.crt
+hab file upload "builder-api-proxy.default" "$(date +%s)" ./ssl-certificate.key
+```
+
+Finally, restarting the builder-api-proxy service will put the updated files into the appropriate path and restart NGINX so that it's using your new certificate and key.
+
+```shell
+hab svc stop habitat/builder-api-proxy && hab svc start habitat/builder-api-proxy
+```
+
+You should now be able to verify through your browser or via an `openssl s_client -connect` command that your builder server has an updated certificate.


### PR DESCRIPTION
This is essentially transferring the PR from https://github.com/habitat-sh/habitat/pull/8429 which intended to add this doc to chef.docs.io. The doc really belongs here instead.