### PR TITLE
introduces BLDR_MINIO_ORIGIN into provision.sh

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -200,7 +200,7 @@ start_datastore() {
 }
 
 start_minio() {
-  sudo hab svc load "${BLDR_ORIGIN}/builder-minio" --channel "${BLDR_MINIO_CHANNEL:=$BLDR_CHANNEL}" --force
+  sudo hab svc load "${BLDR_MINIO_ORIGIN:=$BLDR_ORIGIN}/builder-minio" --channel "${BLDR_MINIO_CHANNEL:=$BLDR_CHANNEL}" --force
 }
 
 start_memcached() {


### PR DESCRIPTION
Small change as part of minio migration via hooks.  Relates to https://github.com/habitat-sh/builder/pull/1860