### PR TITLE
Change go.mod version used with Chef docs

### DIFF
--- a/docs-chef-io/go.mod
+++ b/docs-chef-io/go.mod
@@ -1,3 +1,3 @@
 module github.com/habitat-sh/on-prem-builder/docs-chef-io
 
-go 1.24.2
+go 1.23


### PR DESCRIPTION
The version 1.24.2 in the go.mod file is creating problems when I update other modules with Hugo, so I'm changing this to 1.23.