### PR TITLE
removing core/hab installations

### DIFF
--- a/pkg-sync/main.go
+++ b/pkg-sync/main.go
@@ -33,9 +33,9 @@ func (pl *PackageList) Set(s string) error {
 		pl.Kind = PackageListBuilder
 		pl.List = map[string][]string{
 			"x86_64-linux": []string{
-				"core/hab",
-				"core/hab-sup",
-				"core/hab-launcher",
+				"chef/hab",
+				"chef/hab-sup",
+				"chef/hab-launcher",
 				"habitat/builder-minio",
 				"habitat/builder-memcached",
 				"habitat/builder-datastore",
@@ -48,22 +48,22 @@ func (pl *PackageList) Set(s string) error {
 		pl.Kind = PackageListHabitat
 		pl.List = map[string][]string{
 			"x86_64-linux": []string{
-				"core/hab-studio",
-				"core/hab",
-				"core/hab-sup",
-				"core/hab-launcher",
-				"core/hab-pkg-export-container",
-				"core/hab-pkg-export-tar",
+				"chef/hab-studio",
+				"chef/hab",
+				"chef/hab-sup",
+				"chef/hab-launcher",
+				"chef/hab-pkg-export-container",
+				"chef/hab-pkg-export-tar",
 			},
 			"x86_64-windows": []string{
-				"core/hab-studio",
-				"core/hab-plan-build-ps1",
-				"core/windows-service",
-				"core/hab",
-				"core/hab-sup",
-				"core/hab-launcher",
-				"core/hab-pkg-export-container",
-				"core/hab-pkg-export-tar",
+				"chef/hab-studio",
+				"chef/hab-plan-build-ps1",
+				"chef/windows-service",
+				"chef/hab",
+				"chef/hab-sup",
+				"chef/hab-launcher",
+				"chef/hab-pkg-export-container",
+				"chef/hab-pkg-export-tar",
 			},
 		}
 		return nil

--- a/scripts/install-hab.sh
+++ b/scripts/install-hab.sh
@@ -9,8 +9,9 @@ install_hab() {
 
 install_deps() {
   hab pkg path core/cacerts >/dev/null 2>&1 || hab pkg install core/cacerts
-  hab pkg path core/hab-sup >/dev/null 2>&1 || hab pkg install core/hab-sup
+  hab pkg path chef/hab-sup >/dev/null 2>&1 || hab pkg install chef/hab-sup
 }
 
+hab pkg path chef/hab >/dev/null 2>&1 || install_hab
 type hab > /dev/null 2>&1 || install_hab
 install_deps


### PR DESCRIPTION
This fixes the supervisor installation to pull from the chef origin instead of core. It also updates the package sync tool to pull all hab binaries from the chef origin.