### PR TITLE
fix on-prem provisioning on new ubuntu versions without support for sudo -E

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,28 +8,54 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 
 sudo() {
   if [[ $EUID = 0 ]]; then
-    command sudo "$@"
+    # Already root: no privilege escalation needed, and calling sudo here is
+    # both unnecessary and would fail on systems without sudo installed.
+    "$@"
     return
   fi
 
   # Newer sudo defaults (e.g. Ubuntu 26.04) no longer support "-E", and many
   # sudoers configs disable the SETENV tag, which is what `sudo VAR=val cmd`
-  # relies on. Forwarding the variables as arguments to `env` instead avoids
-  # needing any special sudo privilege, since sudo just sees "env" as the
-  # command being run and the assignments as plain arguments to it. This also
-  # forwards everything scripts/hab-sup.service.sh and scripts/provision.sh
-  # need (proxy settings, HAB_BLDR_URL/PEER_ARG), not just the auth token and
-  # license.
-  local -a forward_env=()
+  # relies on. We also must not pass secrets like HAB_AUTH_TOKEN as `sudo`/
+  # command arguments, since argv is visible to other local users via `ps`.
+  # Instead, write the variables to a temp file that only the owner (and
+  # root) can read, have the root-side shell source it, delete it, and then
+  # exec the real command. This forwards everything scripts/hab-sup.service.sh
+  # and scripts/provision.sh need (proxy settings, HAB_BLDR_URL/PEER_ARG),
+  # not just the auth token and license.
+  local -a forward_vars=()
   local var
   for var in HAB_AUTH_TOKEN HAB_LICENSE HAB_BLDR_URL HAB_BLDR_PEER_ARG \
     HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy \
     SSL_CERT_FILE; do
     if [[ -n "${!var:-}" ]]; then
-      forward_env+=("${var}=${!var}")
+      forward_vars+=("$var")
     fi
   done
-  command sudo env "${forward_env[@]}" "$@"
+
+  if [[ ${#forward_vars[@]} -eq 0 ]]; then
+    command sudo "$@"
+    return
+  fi
+
+  local envfile status
+  envfile="$(mktemp)"
+  chmod 600 "$envfile"
+  for var in "${forward_vars[@]}"; do
+    printf '%s=%q\n' "$var" "${!var}"
+  done >"$envfile"
+
+  command sudo bash -c '
+    set -a
+    # shellcheck disable=SC1090
+    source "$1"
+    rm -f "$1"
+    shift
+    exec "$@"
+  ' _ "$envfile" "$@"
+  status=$?
+  rm -f "$envfile"
+  return $status
 }
 
 check_envfile() {

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ umask 0022
 
 sudo() {
   # the -E pulls in environment variables like HAB_LICENSE
-  [[ $EUID = 0 ]] || set -- command sudo -E "$@"
+  [[ $EUID = 0 ]] || set -- command sudo HAB_AUTH_TOKEN=${HAB_AUTH_TOKEN} HAB_LICENSE=${HAB_LICENSE} "$@"
   "$@"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -41,8 +41,8 @@ fi
 if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
   pushd scripts >/dev/null || exit
   export HAB_LICENSE=accept
-  sudo ./install-hab.sh
   check_envfile
+  sudo ./install-hab.sh
   sudo ./hab-sup.service.sh
   sudo ./provision.sh "$@"
   popd >/dev/null || exit

--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,29 @@
 umask 0022
 
 sudo() {
-  # the -E pulls in environment variables like HAB_LICENSE
-  [[ $EUID = 0 ]] || set -- command sudo HAB_AUTH_TOKEN=${HAB_AUTH_TOKEN} HAB_LICENSE=${HAB_LICENSE} "$@"
-  "$@"
+  if [[ $EUID = 0 ]]; then
+    command sudo "$@"
+    return
+  fi
+
+  # Newer sudo defaults (e.g. Ubuntu 26.04) no longer support "-E", and many
+  # sudoers configs disable the SETENV tag, which is what `sudo VAR=val cmd`
+  # relies on. Forwarding the variables as arguments to `env` instead avoids
+  # needing any special sudo privilege, since sudo just sees "env" as the
+  # command being run and the assignments as plain arguments to it. This also
+  # forwards everything scripts/hab-sup.service.sh and scripts/provision.sh
+  # need (proxy settings, HAB_BLDR_URL/PEER_ARG), not just the auth token and
+  # license.
+  local -a forward_env=()
+  local var
+  for var in HAB_AUTH_TOKEN HAB_LICENSE HAB_BLDR_URL HAB_BLDR_PEER_ARG \
+    HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy \
+    SSL_CERT_FILE; do
+    if [[ -n "${!var:-}" ]]; then
+      forward_env+=("${var}=${!var}")
+    fi
+  done
+  command sudo env "${forward_env[@]}" "$@"
 }
 
 check_envfile() {

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,10 @@
 
 umask 0022
 
+# Resolve paths relative to this script's location (not $PWD) so
+# check_envfile works regardless of the caller's current directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
 sudo() {
   if [[ $EUID = 0 ]]; then
     command sudo "$@"
@@ -29,9 +33,9 @@ sudo() {
 }
 
 check_envfile() {
-  if [ -f ../bldr.env ]; then
+  if [ -f "${SCRIPT_DIR}/bldr.env" ]; then
     # shellcheck disable=SC1091
-    source ../bldr.env
+    source "${SCRIPT_DIR}/bldr.env"
   elif [ -f /vagrant/bldr.env ]; then
     # shellcheck disable=SC1091
     source /vagrant/bldr.env

--- a/scripts/install-hab.sh
+++ b/scripts/install-hab.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 install_hab() {
   type curl >/dev/null 2>&1 || { echo >&2 "curl is required for installation of habitat, but was not found. Exiting."; exit 1; }
-  curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash -s -- -v 1.6.1245
+  curl -fsSL https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash -s -- -v 1.6.1245
 }
 
 install_deps() {

--- a/scripts/install-hab.sh
+++ b/scripts/install-hab.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 install_hab() {
   type curl >/dev/null 2>&1 || { echo >&2 "curl is required for installation of habitat, but was not found. Exiting."; exit 1; }
-  curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash
+  curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash -s -- -v 1.6.1245
 }
 
 install_deps() {

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -6,8 +6,21 @@ umask 0022
 # Defaults
 BLDR_ORIGIN=${BLDR_ORIGIN:="habitat"}
 
+check_envfile() {
+  if [ -f ../bldr.env ]; then
+    # shellcheck disable=SC1091
+    source ../bldr.env
+  elif [ -f /vagrant/bldr.env ]; then
+    # shellcheck disable=SC1091
+    source /vagrant/bldr.env
+  else
+    echo "ERROR: bldr.env file is missing!"
+    exit 1
+  fi
+}
+
 sudo() {
-  [[ $EUID = 0 ]] || set -- command sudo -E "$@"
+  [[ $EUID = 0 ]] || set -- command sudo HAB_AUTH_TOKEN=${HAB_AUTH_TOKEN} HAB_LICENSE=${HAB_LICENSE} "$@"
   "$@"
 }
 
@@ -431,6 +444,7 @@ install_options() {
   fi
 }
 
+check_envfile
 if [ "$#" -eq 0 ]; then
   start_init
   start_builder

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -20,8 +20,28 @@ check_envfile() {
 }
 
 sudo() {
-  [[ $EUID = 0 ]] || set -- command sudo HAB_AUTH_TOKEN=${HAB_AUTH_TOKEN} HAB_LICENSE=${HAB_LICENSE} "$@"
-  "$@"
+  if [[ $EUID = 0 ]]; then
+    command sudo "$@"
+    return
+  fi
+
+  # Newer sudo defaults (e.g. Ubuntu 26.04) no longer support "-E", and many
+  # sudoers configs disable the SETENV tag, which is what `sudo VAR=val cmd`
+  # relies on. Forwarding the variables as arguments to `env` instead avoids
+  # needing any special sudo privilege, since sudo just sees "env" as the
+  # command being run and the assignments as plain arguments to it. This also
+  # forwards everything scripts/hab-sup.service.sh needs (proxy settings,
+  # HAB_BLDR_URL/PEER_ARG), not just the auth token and license.
+  local -a forward_env=()
+  local var
+  for var in HAB_AUTH_TOKEN HAB_LICENSE HAB_BLDR_URL HAB_BLDR_PEER_ARG \
+    HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy \
+    SSL_CERT_FILE; do
+    if [[ -n "${!var:-}" ]]; then
+      forward_env+=("${var}=${!var}")
+    fi
+  done
+  command sudo env "${forward_env[@]}" "$@"
 }
 
 user_toml_warn() {
@@ -444,15 +464,22 @@ install_options() {
   fi
 }
 
+# Handle --help/-h before requiring bldr.env so the help text is available
+# even when the env file hasn't been set up yet.
+for arg in "$@"; do
+  if [ "$arg" == "--help" ] || [ "$arg" == "-h" ]; then
+    Help
+    exit 0
+  fi
+done
+
 check_envfile
 if [ "$#" -eq 0 ]; then
   start_init
   start_builder
 else
   for arg in "$@"; do
-    if [ "$arg" == "--help" ] || [ "$arg" == "-h" ]; then
-      Help
-    elif [ "$arg" == "--install-frontend" ]; then
+    if [ "$arg" == "--install-frontend" ]; then
       export FRONTEND_INSTALL=1
     elif [ "$arg" == "--install-postgresql" ]; then
       export POSTGRESQL_INSTALL=1

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -6,10 +6,14 @@ umask 0022
 # Defaults
 BLDR_ORIGIN=${BLDR_ORIGIN:="habitat"}
 
+# Resolve paths relative to this script's location (not $PWD) so
+# check_envfile works regardless of the caller's current directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
 check_envfile() {
-  if [ -f ../bldr.env ]; then
+  if [ -f "${SCRIPT_DIR}/../bldr.env" ]; then
     # shellcheck disable=SC1091
-    source ../bldr.env
+    source "${SCRIPT_DIR}/../bldr.env"
   elif [ -f /vagrant/bldr.env ]; then
     # shellcheck disable=SC1091
     source /vagrant/bldr.env

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -25,27 +25,54 @@ check_envfile() {
 
 sudo() {
   if [[ $EUID = 0 ]]; then
-    command sudo "$@"
+    # Already root: no privilege escalation needed, and calling sudo here is
+    # both unnecessary and would fail on systems without sudo installed.
+    "$@"
     return
   fi
 
   # Newer sudo defaults (e.g. Ubuntu 26.04) no longer support "-E", and many
   # sudoers configs disable the SETENV tag, which is what `sudo VAR=val cmd`
-  # relies on. Forwarding the variables as arguments to `env` instead avoids
-  # needing any special sudo privilege, since sudo just sees "env" as the
-  # command being run and the assignments as plain arguments to it. This also
-  # forwards everything scripts/hab-sup.service.sh needs (proxy settings,
-  # HAB_BLDR_URL/PEER_ARG), not just the auth token and license.
-  local -a forward_env=()
+  # relies on. We also must not pass secrets like HAB_AUTH_TOKEN as `sudo`/
+  # command arguments, since argv is visible to other local users via `ps`.
+  # Instead, write the variables to a temp file that only the owner (and
+  # root) can read, have the root-side shell source it, delete it, and then
+  # exec the real command. This forwards everything scripts/hab-sup.service.sh
+  # needs (proxy settings, HAB_BLDR_URL/PEER_ARG), not just the auth token and
+  # license.
+  local -a forward_vars=()
   local var
   for var in HAB_AUTH_TOKEN HAB_LICENSE HAB_BLDR_URL HAB_BLDR_PEER_ARG \
     HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy \
     SSL_CERT_FILE; do
     if [[ -n "${!var:-}" ]]; then
-      forward_env+=("${var}=${!var}")
+      forward_vars+=("$var")
     fi
   done
-  command sudo env "${forward_env[@]}" "$@"
+
+  if [[ ${#forward_vars[@]} -eq 0 ]]; then
+    command sudo "$@"
+    return
+  fi
+
+  local envfile status
+  envfile="$(mktemp)"
+  chmod 600 "$envfile"
+  for var in "${forward_vars[@]}"; do
+    printf '%s=%q\n' "$var" "${!var}"
+  done >"$envfile"
+
+  command sudo bash -c '
+    set -a
+    # shellcheck disable=SC1090
+    source "$1"
+    rm -f "$1"
+    shift
+    exec "$@"
+  ' _ "$envfile" "$@"
+  status=$?
+  rm -f "$envfile"
+  return $status
 }
 
 user_toml_warn() {


### PR DESCRIPTION
New version of Ubuntu (26.04) no longer supports the `-E` arg of `sudo` so we end up getting 401's and other errors during on-prem builder installation.

This exports the environment explicitly in the sudo session. It also instals hab 1.6 since 2.x breaks with the stable on-prem packages. Note, that we will change this back to 2.0 with the on-prem release of base packages.